### PR TITLE
[WIP] feat(usageParams): Add host param to be able to use preview api

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,13 @@ Options:
   --export-dir        Defines the path for storing the export json file
                       (default path is the current directory) [string]
 
-  --max-allowed-limit how many item per page per request default 1000 [number]
+  --max-allowed-limit How many item per page per request default 1000 [number]
+
+  --include-drafts    Export Drafts entiries, a preview token needs to be provided when the value is true [boolean]
+
+  --preview-token     Preview API token for the space to be exported. [string] 
+
+  --download-assets   Download the assets along with the exported data [boolean]
 
   --config            Configuration file with required values
 

--- a/dist/run-contentful-export.js
+++ b/dist/run-contentful-export.js
@@ -49,6 +49,10 @@ function runContentfulExport(usageParams) {
     opts.sourceSpace = opts.sourceSpace || usageParams.spaceId;
     opts.sourceManagementToken = opts.sourceManagementToken || usageParams.managementToken;
   }
+  if (opts.includeDrafts) {
+    opts.deliveryHost = 'preview.contentful.com';
+    opts.sourceDeliveryToken = opts.previewToken;
+  }
   var clients = (0, _createClients2.default)(opts);
   return (0, _getFullSourceSpace2.default)({
     managementClient: clients.source.management,

--- a/dist/usageParams.js
+++ b/dist/usageParams.js
@@ -12,6 +12,10 @@ var opts = yargs.version(packageFile.version || 'Version only available on insta
   describe: 'Management API token for the space to be exported.',
   type: 'string',
   demand: true
+}).option('preview-token', {
+  describe: 'Preview API token for the space to be exported.',
+  type: 'string',
+  demand: true
 }).option('export-dir', {
   describe: 'Defines the path for storing the export json file (default path is the current directory)',
   type: 'string'
@@ -19,8 +23,11 @@ var opts = yargs.version(packageFile.version || 'Version only available on insta
   describe: 'With this flags assets will also be downloaded',
   type: 'boolean'
 }).option('max-allowed-limit', {
-  describe: 'how many item per page per request default 1000',
+  describe: 'How many item per page per request default 1000',
   type: 'number'
+}).options('include-drafts', {
+  describe: 'Export Drafts entiries',
+  type: 'boolean'
 }).config('config', 'Configuration file with required values').check(function (argv) {
   if (!argv.spaceId) {
     log.error('Please provide --space-id to be used to export \n' + 'For more info See: https://www.npmjs.com/package/contentful-export');
@@ -30,6 +37,15 @@ var opts = yargs.version(packageFile.version || 'Version only available on insta
     log.error('Please provide --management-token to be used for export \n' + 'For more info See: https://www.npmjs.com/package/contentful-export');
     process.exit(1);
   }
+  if (argv.includeDrafts && !argv.previewToken) {
+    log.error('Please provide a preview API token to be able to get draft or set --include-drafts false');
+    process.exit(1);
+  }
+  if (!argv.includeDrafts && argv.previewToken) {
+    log.error('Please make sure to specify --include-drafts to be able to get drafts');
+    process.exit(1);
+  }
+
   return true;
 }).argv;
 

--- a/lib/run-contentful-export.js
+++ b/lib/run-contentful-export.js
@@ -17,6 +17,10 @@ export default function runContentfulExport (usageParams) {
     opts.sourceSpace = opts.sourceSpace || usageParams.spaceId
     opts.sourceManagementToken = opts.sourceManagementToken || usageParams.managementToken
   }
+  if (opts.includeDrafts) {
+    opts.deliveryHost = 'preview.contentful.com'
+    opts.sourceDeliveryToken = opts.previewToken
+  }
   const clients = createClients(opts)
   return getFullSourceSpace({
     managementClient: clients.source.management,

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -15,6 +15,11 @@ const opts = yargs
     type: 'string',
     demand: true
   })
+  .option('preview-token', {
+    describe: 'Preview API token for the space to be exported.',
+    type: 'string',
+    demand: true
+  })
   .option('export-dir', {
     describe: 'Defines the path for storing the export json file (default path is the current directory)',
     type: 'string'
@@ -24,8 +29,12 @@ const opts = yargs
     type: 'boolean'
   })
   .option('max-allowed-limit', {
-    describe: 'how many item per page per request default 1000',
+    describe: 'How many item per page per request default 1000',
     type: 'number'
+  })
+  .options('include-drafts', {
+    describe: 'Export Drafts entiries',
+    type: 'boolean'
   })
   .config('config', 'Configuration file with required values')
   .check(function (argv) {
@@ -41,6 +50,15 @@ const opts = yargs
       )
       process.exit(1)
     }
+    if (argv.includeDrafts && !argv.previewToken) {
+      log.error('Please provide a preview API token to be able to get draft or set --include-drafts false')
+      process.exit(1)
+    }
+    if (!argv.includeDrafts && argv.previewToken) {
+      log.error('Please make sure to specify --include-drafts to be able to get drafts')
+      process.exit(1)
+    }
+
     return true
   })
   .argv

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "contentful",
     "contentful-export"
   ],
-  "author": "Contentful <opensource@contentful.com>",
+  "author": "Khaled Garbaya <khaled@contentful.com>",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/contentful/contentful-export/issues"
@@ -43,7 +43,7 @@
     "bluebird": "^3.3.3",
     "fs-extra": "^0.30.0",
     "request": "^2.78.0",
-    "contentful-batch-libs": "4.5.0",
+    "contentful-batch-libs": "4.7.0",
     "json-stringify-safe": "^5.0.1",
     "lodash": "^4.0.0",
     "npmlog": "^4.0.0",


### PR DESCRIPTION
This change is exposing a `host` config variable to be able to tell the tool to use a different host instead of the default one for example `preview.contentful.com` to be able to export also Drafts.

This could introduce a Breaking change in the tool.

TODO : 

- [x] Require preview token from user