### PR TITLE
feat(contentful-export): add rate limit options

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,11 @@ Options:
   --preview-token     Preview API token for the space to be exported. [string] 
 
   --download-assets   Download the assets along with the exported data [boolean]
-
+ 
+  --rate-limit                    How many request per period of time, default 6 [number]
+  
+  --rate-limit-period             How much time to wait before retry in ms, default 1000 [number]     
+  
   --config            Configuration file with required values
 
 ```

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -10,6 +10,16 @@ const opts = yargs
     type: 'string',
     demand: true
   })
+  .option('rate-limit', {
+    describe: 'How many requests to perform per period of time, default is 6',
+    type: 'number',
+    default: 6
+  })
+  .option('rate-limit-period', {
+    describe: 'How much time to wait before retry in ms, default 1000',
+    type: 'number',
+    default: 1000
+  })
   .option('management-token', {
     describe: 'Management API token for the space to be exported.',
     type: 'string',


### PR DESCRIPTION
This pull request will add the possibility to the export tool user to adjust the rate limit i.e how many requests per period of time to be sent to Contentfuk