### PR TITLE
Fix error where usageParams were being set incorrectly

### DIFF
--- a/bin/contentful-export
+++ b/bin/contentful-export
@@ -18,6 +18,7 @@ log.info('Contentful Export Tool:\n' +
 'Fetching Space data ...')
 
 setTimeout(function () {
+  // errorLogFile is not set here
   runContentfulExport(usageParams)
   .catch(function (err) {
     log.error('Failed with\n', err)

--- a/lib/run-contentful-export.js
+++ b/lib/run-contentful-export.js
@@ -9,8 +9,21 @@ var log = require('npmlog')
 
 Promise.promisifyAll(fs)
 export default function runContentfulExport (usageParams) {
-  let {opts, errorLogFile} = usageParams
+
+  // Here both opts and errorLogFile are undefined
+  // let {opts, errorLogFile} = usageParams
+  // let opts = usageParams.opts, let errorLogFile = usageParams.errorLogFile
+  // errorLogFile and opts are not set this way when runContentfulExport is called in bin
+  let opts = usageParams;
+
   let exportToFile = true
+  opts.sourceSpace = opts.sourceSpace || usageParams.spaceId;
+  opts.sourceManagementToken = opts.sourceManagementToken || usageParams.managementToken;
+
+  if (opts.exportDir === undefined) {
+    let exportToFile = false
+  }
+
   if (!opts) {
     exportToFile = false
     opts = {}
@@ -77,6 +90,7 @@ export default function runContentfulExport (usageParams) {
     .catch((err) => {
       dumpErrorBuffer({
         sourceSpace: opts.sourceSpace,
+        // errorLogFile is undefinied because 'errorLogFile = usageParams.errorLogFile' is undefined
         errorLogFile: errorLogFile
       })
       throw err


### PR DESCRIPTION
**Observed**: 
When running contentful-export against a space with a larger than max size, the 400 error "Response size too big, was: x. Maximum allowed response size: 7340032b." is thrown. This happens even when maxAllowedLimit is set in options. 

**Reason**: 
This happens because runContentfulExport does not handle usageParams correctly. Inside of the runContentfulExport function, `let {opts, errorLogFile} = usageParams` is set. ES6 interprets this to mean `opts = usageParams.ops` and usageParams does not have the property opts on it. usageParams comes in exactly as it is entered into options. 

**Fix**:
`let opts = usageParams` should be set first. This will fix the issue setting maxAllowedLimit and includeDrafts. However, errorLogFile is still undefined. 

**Next Steps**:
errorLogFile is not used when calling runContentfulExport within contentful-export/bin/contentful-export. 