### PR TITLE
feat(contentful-export): Add api host option

### DIFF
--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -53,6 +53,11 @@ export default yargs
     type: 'number',
     default: 1000
   })
+  .option('management-host', {
+    describe: 'Management API host',
+    type: 'string',
+    default: 'api.contentful.com'
+  })
   .option('error-log-file', {
     describe: 'Full path to the error log file',
     type: 'string'


### PR DESCRIPTION
This PR adds the possibility to specify the API host, this is useful for example if we want to test against staging for example.
The property `managementHost` is coming from [here](https://github.com/contentful/contentful-batch-libs/blob/master/lib/utils/create-clients.js#L40) 