### PR TITLE
fix(proxy): Fix httpsAgent Creation

### DIFF
--- a/lib/utils/proxy.js
+++ b/lib/utils/proxy.js
@@ -57,7 +57,7 @@ export function agentFromProxy (proxy) {
   })
   const { host, port } = proxy
   const agent = new HttpsProxyAgent({ host, port })
-  return { httpsAgent: agent }
+  return agent
 }
 
 export function proxyObjectToString (proxyObject) {


### PR DESCRIPTION
[`options.httsAgent`](https://github.com/contentful/contentful-export/blob/master/lib/parseOptions.js#L56) needs to be an `httpsAgent` and not a `{httpsAgent: agent}` object
