### PR TITLE
feat: seperate querying for entries and assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,9 @@ Options:
 
   --content-only          Only export entries and assets [boolean] [default: false]
 
-  --query                 Exports only entries assets that matches these queries [array]
+  --query-entries         Exports only entries that matches these queries [array]
+
+  --query-assets          Exports only assets that matches these queries [array]
 
   --content-file          The filename for the exported data [string]
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -69,7 +69,8 @@ export default function runContentfulExport (params) {
           skipWebhooks: options.skipWebhooks,
           skipRoles: options.skipRoles,
           listrOptions,
-          query: options.query
+          queryEntries: options.queryEntries,
+          queryAssets: options.queryAssets
         })
       }
     },

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -70,8 +70,12 @@ export default yargs
     describe: 'Full path to the error log file',
     type: 'string'
   })
-  .option('query', {
+  .option('query-entries', {
     describe: 'Exports only entries that matches these queries',
+    type: 'array'
+  })
+  .option('query-assets', {
+    describe: 'Exports only assets that matches these queries',
     type: 'array'
   })
   .option('content-file', {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "blue-tape": "^1.0.0",
     "bluebird": "^3.3.3",
     "cli-table2": "^0.2.0",
-    "contentful-batch-libs": "8.0.0-beta3",
+    "contentful-batch-libs": "8.0.0-beta4",
     "figures": "^2.0.0",
     "fs-extra": "^3.0.1",
     "https-proxy-agent": "^2.0.0",


### PR DESCRIPTION
This PR is splitting `--query` into `--query-entries` and `--query-assets` 

- [x] Change batch libs dependency