### PR TITLE
use file.end() instead of file.close()

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg)](http://standardjs.com/)
 
-[https://www.contentful.com](Contentful) is a content management platform for web applications, mobile apps and connected devices. It allows you to create, edit & manage content in the cloud and publish it anywhere via powerful API. Contentful offers tools for managing editorial teams and enabling cooperation between organizations.
+[Contentful](https://www.contentful.com) provides a content infrastructure for digital teams to power content in websites, apps, and devices. Unlike a CMS, Contentful was built to integrate with the modern software stack. It offers a central hub for structured content, powerful management and delivery APIs, and a customizable web app that enable developers and content creators to ship digital products faster.
 
 This is a command line tool (CLI) that help you backup your published Content Model, Content and Assets or move them to a new Contentful space. _It will support Editor Interfaces, Webhooks and Roles & Permissions in a future version._
 

--- a/lib/download-asset.js
+++ b/lib/download-asset.js
@@ -32,7 +32,7 @@ export default function downloadAsset (url, directory) {
       response.pipe(file)
 
       file.on('finish', function () {
-        file.close()
+        file.end()
         resolve(localFile)
       })
     })


### PR DESCRIPTION
This is the officially supported non breaking API.
Tested on node 9.2.0