### PR TITLE
add `--include-archived` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,9 @@ The filename for the exported data
 #### `includeDrafts` [boolean] [default: false]
 Include drafts in the exported entries
 
+#### `includeArchived` [boolean] [default: false]
+Include archived entries in the exported entries
+
 #### `skipContentModel` [boolean] [default: false]
 Skip exporting content models
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -68,6 +68,7 @@ export default function runContentfulExport (params) {
           environmentId: options.environmentId,
           maxAllowedLimit: options.maxAllowedLimit,
           includeDrafts: options.includeDrafts,
+          includeArchived: options.includeArchived,
           skipContentModel: options.skipContentModel,
           skipContent: options.skipContent,
           skipWebhooks: options.skipWebhooks,

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -13,6 +13,7 @@ export default function parseOptions (params) {
     environmentId: 'master',
     exportDir: process.cwd(),
     includeDrafts: false,
+    includeArchived: false,
     skipRoles: false,
     skipContentModel: false,
     skipContent: false,

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -21,6 +21,7 @@ export default function getFullSourceSpace ({
   skipWebhooks,
   skipRoles,
   includeDrafts,
+  includeArchived,
   maxAllowedLimit,
   listrOptions,
   queryEntries,
@@ -74,6 +75,7 @@ export default function getFullSourceSpace ({
         return pagedGet({source: ctx.environment, method: 'getEntries', query: queryEntries})
           .then(extractItems)
           .then((items) => filterDrafts(items, includeDrafts))
+          .then((items) => filterArchived(items, includeArchived))
           .then((items) => {
             ctx.data.entries = items
           })
@@ -86,6 +88,7 @@ export default function getFullSourceSpace ({
         return pagedGet({source: ctx.environment, method: 'getAssets', query: queryAssets})
           .then(extractItems)
           .then((items) => filterDrafts(items, includeDrafts))
+          .then((items) => filterArchived(items, includeArchived))
           .then((items) => {
             ctx.data.assets = items
           })
@@ -183,5 +186,9 @@ function extractItems (response) {
 }
 
 function filterDrafts (items, includeDrafts) {
-  return includeDrafts ? items : items.filter((item) => !!item.sys.publishedVersion)
+  return includeDrafts ? items : items.filter((item) => !!item.sys.publishedVersion || !!item.sys.archivedVersion)
+}
+
+function filterArchived (items, includeArchived) {
+  return includeArchived ? items : items.filter((item) => !item.sys.archivedVersion)
 }

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -28,6 +28,11 @@ export default yargs
     type: 'boolean',
     default: false
   })
+  .option('include-archived', {
+    describe: 'Include archived entries in the exported entries',
+    type: 'boolean',
+    default: false
+  })
   .option('skip-content-model', {
     describe: 'Skip exporting content models',
     type: 'boolean',

--- a/test/unit/parseOptions.test.js
+++ b/test/unit/parseOptions.test.js
@@ -38,6 +38,7 @@ test('parseOptions sets correct default options', () => {
   expect(options.errorLogFile).toMatch(new RegExp(`^${resolve(basePath, errorFileNamePattern)}$`))
   expect(options.exportDir).toBe(basePath)
   expect(options.includeDrafts).toBe(false)
+  expect(options.includeArchived).toBe(false)
   expect(options.logFilePath).toMatch(new RegExp(`^${resolve(basePath, contentFileNamePattern)}$`))
   expect(options.application).toBe(`contentful.export/${version}`)
   expect(options.feature).toBe(`library-export`)

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -254,6 +254,37 @@ test('Gets whole destination content with drafts', () => {
     })
 })
 
+test('Gets whole destination content with archived entries', () => {
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    includeDrafts: true,
+    includeArchived: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      expect(mockClient.getSpace.mock.calls).toHaveLength(1)
+      expect(mockSpace.getEnvironment.mock.calls).toHaveLength(1)
+      expect(mockEnvironment.getContentTypes.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockEnvironment.getEntries.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockEnvironment.getAssets.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockEnvironment.getLocales.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockSpace.getWebhooks.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockSpace.getRoles.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(getEditorInterface.mock.calls).toHaveLength(resultItemCount)
+      expect(response.data.contentTypes).toHaveLength(resultItemCount)
+      expect(response.data.entries).toHaveLength(resultItemCount)
+      expect(response.data.assets).toHaveLength(resultItemCount)
+      expect(response.data.locales).toHaveLength(resultItemCount)
+      expect(response.data.webhooks).toHaveLength(resultItemCount)
+      expect(response.data.roles).toHaveLength(resultItemCount)
+      expect(response.data.editorInterfaces).toHaveLength(resultItemCount)
+    })
+})
+
 test('Skips webhooks & roles for non-master environments', () => {
   return getSpaceData({
     client: mockClient,


### PR DESCRIPTION
fixes #123 so `--include-drafts` only includes draft entries (and not archived entries) and adds `--include-archived` to include archived entries