### PR TITLE
Added a separate option to skip only editor interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,9 @@ Include archived entries in the exported entries
 #### `skipContentModel` [boolean] [default: false]
 Skip exporting content models
 
+#### `skipEditorInterfaces` [boolean] [default: false]
+Skip exporting editor interfaces
+
 #### `skipContent` [boolean] [default: false]
 Skip exporting assets and entries
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,6 +70,7 @@ export default function runContentfulExport (params) {
           includeDrafts: options.includeDrafts,
           includeArchived: options.includeArchived,
           skipContentModel: options.skipContentModel,
+          skipEditorInterfaces: options.skipEditorInterfaces,
           skipContent: options.skipContent,
           skipWebhooks: options.skipWebhooks,
           skipRoles: options.skipRoles,

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -16,6 +16,7 @@ export default function parseOptions (params) {
     includeArchived: false,
     skipRoles: false,
     skipContentModel: false,
+    skipEditorInterfaces: false,
     skipContent: false,
     skipWebhooks: false,
     maxAllowedLimit: 1000,

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -17,6 +17,7 @@ export default function getFullSourceSpace ({
   spaceId,
   environmentId = 'master',
   skipContentModel,
+  skipEditorInterfaces,
   skipContent,
   skipWebhooks,
   skipRoles,
@@ -67,7 +68,7 @@ export default function getFullSourceSpace ({
             })
           })
       }),
-      skip: (ctx) => skipContentModel || (ctx.data.contentTypes.length === 0 && 'Skipped since no content types downloaded')
+      skip: (ctx) => skipEditorInterfaces || skipContentModel || (ctx.data.contentTypes.length === 0 && 'Skipped since no content types downloaded')
     },
     {
       title: 'Fetching content entries data',

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -171,6 +171,7 @@ test('Creates a valid and correct opts object', () => {
   })
     .then(() => {
       expect(initClient.mock.calls[0][0].skipContentModel).toBeFalsy()
+      expect(initClient.mock.calls[0][0].skipEditorInterfaces).toBeFalsy()
       expect(initClient.mock.calls[0][0].errorLogFile).toBe(resolve(process.cwd(), errorLogFile))
       expect(initClient.mock.calls[0][0].spaceId).toBe(exampleConfig.spaceId)
       expect(initClient.mock.calls).toHaveLength(1)

--- a/test/unit/parseOptions.test.js
+++ b/test/unit/parseOptions.test.js
@@ -47,6 +47,7 @@ test('parseOptions sets correct default options', () => {
   expect(options.saveFile).toBe(true)
   expect(options.skipContent).toBe(false)
   expect(options.skipContentModel).toBe(false)
+  expect(options.skipEditorInterfaces).toBe(false)
   expect(options.skipRoles).toBe(false)
   expect(options.skipWebhooks).toBe(false)
   expect(options.spaceId).toBe(spaceId)

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -164,6 +164,36 @@ test('Gets whole destination content without content', () => {
     })
 })
 
+test('Gets whole destination content without editor interfaces', () => {
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    skipEditorInterfaces: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      expect(mockClient.getSpace.mock.calls).toHaveLength(1)
+      expect(mockSpace.getEnvironment.mock.calls).toHaveLength(1)
+      expect(mockEnvironment.getContentTypes.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockEnvironment.getEntries.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockEnvironment.getAssets.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockEnvironment.getLocales.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockSpace.getWebhooks.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockSpace.getRoles.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(getEditorInterface.mock.calls).toHaveLength(0)
+      expect(response.data.contentTypes).toHaveLength(resultItemCount)
+      expect(response.data.entries).toHaveLength(resultItemCount / 2)
+      expect(response.data.assets).toHaveLength(resultItemCount / 2)
+      expect(response.data.locales).toHaveLength(resultItemCount)
+      expect(response.data.webhooks).toHaveLength(resultItemCount)
+      expect(response.data.roles).toHaveLength(resultItemCount)
+      expect(response.data.editorInterfaces).toBeUndefined()
+    })
+})
+
 test('Gets whole destination content without webhooks', () => {
   return getSpaceData({
     client: mockClient,


### PR DESCRIPTION
To be used when the content model is still needed, but the editor intefaces are not