### PR TITLE
chore(linter): fix eslint issues to enable npm lint cmd again

### DIFF
--- a/bin/contentful-export
+++ b/bin/contentful-export
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-var runContentfulExport = require('../dist/index')
-var usageParams = require('../dist/usageParams')
+const runContentfulExport = require('../dist/index')
+const usageParams = require('../dist/usageParams')
 
 console.log('We moved the CLI version of this tool into our Contentful CLI.\nThis allows our users to use and install only one single CLI tool to get the full Contentful experience.\nFor more info please visit https://github.com/contentful/contentful-cli/tree/master/docs/space/export')
 

--- a/lib/tasks/download-assets.js
+++ b/lib/tasks/download-assets.js
@@ -10,13 +10,13 @@ import getEntityName from 'contentful-batch-libs/dist/get-entity-name'
 function downloadAsset (url, directory) {
   return new Promise(function (resolve, reject) {
     // build local file path from the url for the download
-    var urlParts = url.split('//')
+    const urlParts = url.split('//')
 
-    var localFile = path.join(directory, urlParts[urlParts.length - 1])
+    const localFile = path.join(directory, urlParts[urlParts.length - 1])
 
     // ensure directory exists and create file stream
     fs.mkdirsSync(path.dirname(localFile))
-    var file = fs.createWriteStream(localFile)
+    const file = fs.createWriteStream(localFile)
 
     // handle urls without protocol
     if (url.startsWith('//')) {
@@ -24,7 +24,7 @@ function downloadAsset (url, directory) {
     }
 
     // download asset
-    var assetRequest = request.get(url)
+    const assetRequest = request.get(url)
 
     // pipe response content to file
     assetRequest

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -62,14 +62,14 @@ export default function getFullSourceSpace ({
     {
       title: 'Fetching tags data',
       task: wrapTask((ctx, task) => {
-        return pagedGet({source: ctx.environment, method: 'getTags'})
-            .then(extractItems)
-            .then((items) => {
-              ctx.data.tags = items
-            })
-            .catch(e => {
-              ctx.data.tags = []
-            })
+        return pagedGet({ source: ctx.environment, method: 'getTags' })
+          .then(extractItems)
+          .then((items) => {
+            ctx.data.tags = items
+          })
+          .catch(e => {
+            ctx.data.tags = []
+          })
       }),
       skip: () => cdaClient
     },
@@ -184,7 +184,7 @@ function pagedGet ({ source, method, skip = 0, aggregatedResponse = null, query 
   let queryLimit = query && query.limit
   if (queryLimit && aggregatedResponse) {
     if (skip + pageLimit > queryLimit) { // this means the total we are about to fetch is > our limit
-      queryLimit =  queryLimit % pageLimit
+      queryLimit = queryLimit % pageLimit
     }
   }
   const fullQuery = Object.assign({},

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -36,7 +36,7 @@ const mockClient = {}
 
 const getEditorInterface = jest.fn()
 
-const mockEntry = { metadata: {tags: []}}
+const mockEntry = { metadata: { tags: [] } }
 
 function setupMocks () {
   mockClient.getSpace = jest.fn(() => Promise.resolve(mockSpace))
@@ -443,9 +443,8 @@ test('Loads 1000 items per page by default', () => {
     })
 })
 
-
 test('Query entry/asset respect limit query param', () => {
-  //overwrite the getAssets mock so maxItems is larger than default page size in pagedGet (get-space-data.js)
+  // overwrite the getAssets mock so maxItems is larger than default page size in pagedGet (get-space-data.js)
   mockEnvironment.getAssets = jest.fn((query) => {
     return Promise.resolve(pagedContentResult(query, 2000, mockEntry))
   })
@@ -456,8 +455,8 @@ test('Query entry/asset respect limit query param', () => {
     skipWebhooks: true,
     skipRoles: true,
     includeDrafts: true,
-    queryEntries: {limit: 20}, // test limit < pageSize
-    queryAssets: {limit: 1001} // test limit > pageSize
+    queryEntries: { limit: 20 }, // test limit < pageSize
+    queryAssets: { limit: 1001 } // test limit > pageSize
   })
     .run({
       data: {}


### PR DESCRIPTION
The `npm run lint` command throws errors in a local setup on master and demands changes. Those are the changes applied via the eslint `--fix` option.