### PR TITLE
fix(assets-output): change firgure for asset's error from warning to …

### DIFF
--- a/lib/tasks/download-assets.js
+++ b/lib/tasks/download-assets.js
@@ -57,7 +57,7 @@ export default function downloadAssets (options) {
       return Promise.mapSeries(locales, (locale) => {
         const url = asset.fields.file[locale].url
         if (!url) {
-          task.output = `${figures.warning} asset '${getEntityName(asset)}' doesn't contain an url in path asset.fields.file[${locale}].url`
+          task.output = `${figures.cross} asset '${getEntityName(asset)}' doesn't contain an url in path asset.fields.file[${locale}].url`
           errorCount++
 
           return Promise.resolve()


### PR DESCRIPTION
Nit fix: the error message for assets missing the file URL should contain a cross instead of a warning figure