### PR TITLE
feat: add custom headers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,13 @@ Pass proxy config to Axios instead of creating a custom httpsAgent
 #### `maxAllowedLimit` [number] [default: 1000]
 The number of items per page per request
 
-#### 'limit' [number]
+#### `limit` [number]
 The total number of items to return. Can be used with entries or assets. If not provided, then all entries or assets will be returned. The entries or assets will be ordered using: `sys.createdAt,sys.id`.
+
+#### `headers` [object]
+
+Additional headers to attach to the requests. 
+
 
 ### Other
 

--- a/README.md
+++ b/README.md
@@ -212,9 +212,7 @@ The number of items per page per request
 The total number of items to return. Can be used with entries or assets. If not provided, then all entries or assets will be returned. The entries or assets will be ordered using: `sys.createdAt,sys.id`.
 
 #### `headers` [object]
-
 Additional headers to attach to the requests. 
-
 
 ### Other
 

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -2,52 +2,12 @@ import { resolve } from 'path'
 
 import moment from 'moment'
 
+import { getHeadersConfig } from './utils/headers'
 import { proxyStringToObject, agentFromProxy } from 'contentful-batch-libs/dist/proxy'
 
 import { version } from '../package'
 
 import qs from 'querystring'
-
-/**
- * Turn header option into an object. Invalid header values
- * are ignored.
- *
- * @example
- * getHeadersConfig('Accept: Any')
- * // -> {Accept: 'Any'}
- *
- * @example
- * getHeadersConfig(['Accept: Any', 'X-Version: 1'])
- * // -> {Accept: 'Any', 'X-Version': '1'}
- *
- * @param value {string|string[]}
- */
-function getHeadersConfig (value) {
-  if (!value) {
-    return {}
-  }
-
-  const values = Array.isArray(value) ? value : [value]
-
-  return values.reduce((headers, value) => {
-    value = value.trim()
-
-    const separatorIndex = value.indexOf(':')
-
-    // Invalid header format
-    if (separatorIndex === -1) {
-      return headers
-    }
-
-    const headerKey = value.slice(0, separatorIndex).trim()
-    const headerValue = value.slice(separatorIndex + 1).trim()
-
-    return {
-      ...headers,
-      [headerKey]: headerValue
-    }
-  }, {})
-}
 
 export default function parseOptions (params) {
   const defaultOptions = {

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -8,6 +8,47 @@ import { version } from '../package'
 
 import qs from 'querystring'
 
+/**
+ * Turn header option into an object. Invalid header values
+ * are ignored.
+ *
+ * @example
+ * getHeadersConfig('Accept: Any')
+ * // -> {Accept: 'Any'}
+ *
+ * @example
+ * getHeadersConfig(['Accept: Any', 'X-Version: 1'])
+ * // -> {Accept: 'Any', 'X-Version': '1'}
+ *
+ * @param value {string|string[]}
+ */
+function getHeadersConfig (value) {
+  if (!value) {
+    return {}
+  }
+
+  const values = Array.isArray(value) ? value : [value]
+
+  return values.reduce((headers, value) => {
+    value = value.trim()
+
+    const separatorIndex = value.indexOf(':')
+
+    // Invalid header format
+    if (separatorIndex === -1) {
+      return headers
+    }
+
+    const headerKey = value.slice(0, separatorIndex).trim()
+    const headerValue = value.slice(separatorIndex + 1).trim()
+
+    return {
+      ...headers,
+      [headerKey]: headerValue
+    }
+  }, {})
+}
+
 export default function parseOptions (params) {
   const defaultOptions = {
     environmentId: 'master',
@@ -32,7 +73,8 @@ export default function parseOptions (params) {
   const options = {
     ...defaultOptions,
     ...configFile,
-    ...params
+    ...params,
+    headers: params.headers || getHeadersConfig(params.header)
   }
 
   // Validation

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -111,5 +111,10 @@ export default yargs
     type: 'boolean',
     default: false
   })
+  .option('header', {
+    alias: 'H',
+    type: 'string',
+    describe: 'Pass an additional HTTP Header'
+  })
   .config('config', 'An optional configuration JSON file containing all the options for a single run')
   .argv

--- a/lib/utils/headers.js
+++ b/lib/utils/headers.js
@@ -1,0 +1,40 @@
+/**
+ * Turn header option into an object. Invalid header values
+ * are ignored.
+ *
+ * @example
+ * getHeadersConfig('Accept: Any')
+ * // -> {Accept: 'Any'}
+ *
+ * @example
+ * getHeadersConfig(['Accept: Any', 'X-Version: 1'])
+ * // -> {Accept: 'Any', 'X-Version': '1'}
+ *
+ * @param value {string|string[]}
+ */
+export function getHeadersConfig (value) {
+  if (!value) {
+    return {}
+  }
+
+  const values = Array.isArray(value) ? value : [value]
+
+  return values.reduce((headers, value) => {
+    value = value.trim()
+
+    const separatorIndex = value.indexOf(':')
+
+    // Invalid header format
+    if (separatorIndex === -1) {
+      return headers
+    }
+
+    const headerKey = value.slice(0, separatorIndex).trim()
+    const headerValue = value.slice(separatorIndex + 1).trim()
+
+    return {
+      ...headers,
+      [headerKey]: headerValue
+    }
+  }, {})
+}

--- a/test/unit/parseOptions.test.js
+++ b/test/unit/parseOptions.test.js
@@ -183,3 +183,18 @@ test('parseOption parses deliveryToken option', () => {
   expect(options.spaceId).toBe(spaceId)
   expect(options.deliveryToken).toBe('testDeliveryToken')
 })
+
+test('parseOption parses headers option', () => {
+  const options = parseOptions({
+    spaceId,
+    managementToken,
+    headers: {
+      header1: '1',
+      header2: '2'
+    }
+  })
+  expect(options.headers).toEqual({
+    header1: '1',
+    header2: '2'
+  })
+})

--- a/test/unit/parseOptions.test.js
+++ b/test/unit/parseOptions.test.js
@@ -198,3 +198,12 @@ test('parseOption parses headers option', () => {
     header2: '2'
   })
 })
+
+test('parses params.header if provided', function () {
+  const config = parseOptions({
+    spaceId,
+    managementToken,
+    header: ['Accept   : application/json ', ' X-Header: 1']
+  })
+  expect(config.headers).toEqual({ Accept: 'application/json', 'X-Header': '1' })
+})

--- a/test/unit/utils/headers.test.js
+++ b/test/unit/utils/headers.test.js
@@ -1,0 +1,35 @@
+const { getHeadersConfig } = require('../../../lib/utils/headers')
+
+test('getHeadersConfig returns empty object when value is undefined', () => {
+  expect(getHeadersConfig(undefined)).toEqual({})
+})
+
+test('getHeadersConfig accepts single or multiple values', () => {
+  expect(getHeadersConfig('Accept: Any')).toEqual({ Accept: 'Any' })
+  expect(getHeadersConfig(['Accept: Any', 'X-Version: 1'])).toEqual({
+    Accept: 'Any',
+    'X-Version': '1'
+  })
+})
+
+test('getHeadersConfig ignores invalid headers', () => {
+  expect(
+    getHeadersConfig(['Accept: Any', 'X-Version: 1', 'invalid'])
+  ).toEqual({
+    Accept: 'Any',
+    'X-Version': '1'
+  })
+})
+
+test('getHeadersConfig trims spacing around keys & values', () => {
+  expect(
+    getHeadersConfig([
+      '  Accept:   Any   ',
+      '   X-Version   :1 ',
+      'invalid'
+    ])
+  ).toEqual({
+    Accept: 'Any',
+    'X-Version': '1'
+  })
+})


### PR DESCRIPTION
Added _explicit_ support for passing `headers` option down to `contentful-management`. 

A similar option/flag will be added to other related libraries as well (e.g. `contentful-import`).