### PR TITLE
feat(header): add standard header

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 [Contentful](https://www.contentful.com) provides a content infrastructure for digital teams to power content in websites, apps, and devices. Unlike a CMS, Contentful was built to integrate with the modern software stack. It offers a central hub for structured content, powerful management and delivery APIs, and a customizable web app that enable developers and content creators to ship digital products faster.
 
-This is a library that help you backup your Content Model, Content and Assets or move them to a new Contentful space. _It will support Roles & Permissions in a future version._
+This is a library that helps you backup your Content Model, Content and Assets or move them to a new Contentful space. _It will support Roles & Permissions in a future version._
 
 To import your exported data, please refer to the [contentful-import](https://github.com/contentful/contentful-import) repository.
 

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -34,7 +34,7 @@ export default function parseOptions (params) {
     ...defaultOptions,
     ...configFile,
     ...params,
-    headers: params.headers || getHeadersConfig(params.header)
+    headers: getHeadersConfig(params.headers ? params.headers : params.header)
   }
 
   // Validation

--- a/lib/utils/headers.js
+++ b/lib/utils/headers.js
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid'
+
 /**
  * Turn header option into an object. Invalid header values
  * are ignored.
@@ -17,11 +19,16 @@ export function getHeadersConfig (value) {
     return {}
   }
 
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return addSequenceHeader(value)
+  }
+
   const values = Array.isArray(value) ? value : [value]
 
-  return values.reduce((headers, value) => {
+  const formattedHeaders = values.reduce((headers, value) => {
     value = value.trim()
 
+    console.log(value)
     const separatorIndex = value.indexOf(':')
 
     // Invalid header format
@@ -37,4 +44,19 @@ export function getHeadersConfig (value) {
       [headerKey]: headerValue
     }
   }, {})
+
+  return addSequenceHeader(formattedHeaders)
+}
+
+/**
+ * Adds sequence header to a headers object
+ * @param headers {object}
+ *
+ */
+function addSequenceHeader (headers) {
+  return {
+    ...headers,
+    // Unique sequence header
+    'CF-Sequence': uuidv4()
+  }
 }

--- a/test/unit/parseOptions.test.js
+++ b/test/unit/parseOptions.test.js
@@ -195,7 +195,8 @@ test('parseOption parses headers option', () => {
   })
   expect(options.headers).toEqual({
     header1: '1',
-    header2: '2'
+    header2: '2',
+    'CF-Sequence': expect.any(String)
   })
 })
 
@@ -205,5 +206,5 @@ test('parses params.header if provided', function () {
     managementToken,
     header: ['Accept   : application/json ', ' X-Header: 1']
   })
-  expect(config.headers).toEqual({ Accept: 'application/json', 'X-Header': '1' })
+  expect(config.headers).toEqual({ Accept: 'application/json', 'X-Header': '1', 'CF-Sequence': expect.any(String) })
 })

--- a/test/unit/utils/headers.test.js
+++ b/test/unit/utils/headers.test.js
@@ -5,10 +5,14 @@ test('getHeadersConfig returns empty object when value is undefined', () => {
 })
 
 test('getHeadersConfig accepts single or multiple values', () => {
-  expect(getHeadersConfig('Accept: Any')).toEqual({ Accept: 'Any' })
+  expect(getHeadersConfig('Accept: Any')).toEqual({
+    Accept: 'Any',
+    'CF-Sequence': expect.any(String)
+  })
   expect(getHeadersConfig(['Accept: Any', 'X-Version: 1'])).toEqual({
     Accept: 'Any',
-    'X-Version': '1'
+    'X-Version': '1',
+    'CF-Sequence': expect.any(String)
   })
 })
 
@@ -17,7 +21,8 @@ test('getHeadersConfig ignores invalid headers', () => {
     getHeadersConfig(['Accept: Any', 'X-Version: 1', 'invalid'])
   ).toEqual({
     Accept: 'Any',
-    'X-Version': '1'
+    'X-Version': '1',
+    'CF-Sequence': expect.any(String)
   })
 })
 
@@ -30,6 +35,7 @@ test('getHeadersConfig trims spacing around keys & values', () => {
     ])
   ).toEqual({
     Accept: 'Any',
-    'X-Version': '1'
+    'X-Version': '1',
+    'CF-Sequence': expect.any(String)
   })
 })


### PR DESCRIPTION
Adds a standard header to the requests targetting the backend.

### Open questions

Should we still support both `header` and `headers` parameters?
At the moment there seems to be a mix. While the documentation only describes `headers`, the usageParams.js only describes `header`.