### PR TITLE
chore(dependabot): Ignore figures package

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
     - dependency-name: husky
       versions:
         - ">=5.0.0"
+    - dependency-name: figures # Pure ESM module. Remove when supporting ESM
+      versions:
+        - ">=4.0.0"
     commit-message:
       prefix: build
       include: scope


### PR DESCRIPTION
Ignore figures package (>=4.0.0) in depenadabot because it's a pure ESM package.