### PR TITLE
Add type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-determined-by-semantic-release",
   "description": "this tool allows you to export a space to a JSON dump",
   "main": "dist/index.js",
+  "types": "types.d.ts",
   "engines": {
     "node": ">=12"
   },
@@ -95,7 +96,8 @@
     "bin",
     "dist",
     "example-config.json",
-    "index.js"
+    "index.js",
+    "types.d.ts"
   ],
   "config": {
     "commitizen": {

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,34 @@
+export interface Options {
+  managementToken: string;
+  spaceId: string;
+
+  contentFile?: string;
+  contentOnly?: boolean;
+  deliveryToken?: string;
+  environmentId?: string;
+  errorLogFile?: string;
+  exportDir?: string;
+  host?: string;
+  includeArchived?: boolean;
+  includeDrafts?: boolean;
+  limit?: number;
+  managementApplication?: string;
+  managementFeature?: string;
+  maxAllowedLimit?: boolean;
+  proxy?: string;
+  queryEntries?: string | string[];
+  rawProxy?: boolean;
+  saveFile?: boolean;
+  skipContent?: boolean;
+  skipContentModel?: boolean;
+  skipEditorInferfaces?: boolean;
+  skipRoles?: boolean;
+  skipWebhooks?: boolean;
+  useVerboseRenderer?: boolean;
+};
+
+
+type ContentfulExportField = 'contentTypes' | 'entries' | 'assets' | 'locales' | 'tags' | 'webhooks' | 'roles' | 'editorInterfaces';
+
+declare const runContentfulExport: (params: Options) => Promise<Record<ContentfulExportField, unknown[]>>;
+export default runContentfulExport;


### PR DESCRIPTION
# Details

This PR adds Typescript support for the current package exports: `runContentfulExport`. I am not sure on the deployment processes, but this change will require a package version bump. 

This addresses this related issue: https://github.com/contentful/contentful-export/issues/376

It should also be noted that the current lint parser does not support Typescript syntax, however this does not fail the `lint` script as it is not included under the directories `lib` or `bin`.