### PR TITLE
Add 'includeChanged' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ Content Delivery API.
 #### `includeArchived` [boolean] [default: false]
 Include archived entries in the exported entries
 
+#### `includeChanged` [boolean] [default: false]
+Include changed entries in the exported entries
+
 #### `skipContentModel` [boolean] [default: false]
 Skip exporting content models
 

--- a/example-config.json
+++ b/example-config.json
@@ -8,6 +8,7 @@
   "contentFile": "export.json",
   "includeDrafts": false,
   "includeArchived": false,
+  "includeChanged": false,
   "skipContentModel": false,
   "skipEditorInterfaces": false,
   "skipContent": false,

--- a/lib/index.js
+++ b/lib/index.js
@@ -74,6 +74,7 @@ export default function runContentfulExport (params) {
           maxAllowedLimit: options.maxAllowedLimit,
           includeDrafts: options.includeDrafts,
           includeArchived: options.includeArchived,
+          includeChanged: options.includeChanged,
           skipContentModel: options.skipContentModel,
           skipEditorInterfaces: options.skipEditorInterfaces,
           skipContent: options.skipContent,

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -16,6 +16,7 @@ export default function parseOptions (params) {
     exportDir: process.cwd(),
     includeDrafts: false,
     includeArchived: false,
+    includeChanged: false,
     skipRoles: false,
     skipContentModel: false,
     skipEditorInterfaces: false,

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -24,6 +24,7 @@ export default function getFullSourceSpace ({
   skipEditorInterfaces,
   includeDrafts,
   includeArchived,
+  includeChanged,
   maxAllowedLimit,
   listrOptions,
   queryEntries,
@@ -99,6 +100,7 @@ export default function getFullSourceSpace ({
           .then(extractItems)
           .then((items) => filterDrafts(items, includeDrafts, cdaClient))
           .then((items) => filterArchived(items, includeArchived))
+          .then((items) => filterChanged(items, includeChanged))
           .then((items) => {
             ctx.data.entries = items
           })
@@ -115,6 +117,7 @@ export default function getFullSourceSpace ({
           .then(extractItems)
           .then((items) => filterDrafts(items, includeDrafts, cdaClient))
           .then((items) => filterArchived(items, includeArchived))
+          .then((items) => filterChanged(items, includeChanged))
           .then((items) => {
             ctx.data.assets = items
           })
@@ -227,4 +230,8 @@ function filterDrafts (items, includeDrafts, cdaClient) {
 
 function filterArchived (items, includeArchived) {
   return includeArchived ? items : items.filter((item) => !item.sys.archivedVersion)
+}
+
+function filterChanged (items, includeChanged) {
+  return includeChanged ? items : items.filter((item) => !item.sys.changedVersion)
 }

--- a/test/unit/parseOptions.test.js
+++ b/test/unit/parseOptions.test.js
@@ -39,6 +39,7 @@ test('parseOptions sets correct default options', () => {
   expect(options.exportDir).toBe(basePath)
   expect(options.includeDrafts).toBe(false)
   expect(options.includeArchived).toBe(false)
+  expect(options.includeChanged).toBe(false)
   expect(options.logFilePath).toMatch(new RegExp(`^${resolve(basePath, contentFileNamePattern)}$`))
   expect(options.application).toBe(`contentful.export/${version}`)
   expect(options.feature).toBe('library-export')

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -337,6 +337,39 @@ test('Gets whole destination content with archived entries', () => {
     })
 })
 
+test('Gets whole destination content with changed entries', () => {
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    includeDrafts: true,
+    includeChanged: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      expect(mockClient.getSpace.mock.calls).toHaveLength(1)
+      expect(mockSpace.getEnvironment.mock.calls).toHaveLength(1)
+      expect(mockEnvironment.getContentTypes.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockEnvironment.getEntries.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockEnvironment.getAssets.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockEnvironment.getLocales.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockEnvironment.getTags.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockSpace.getWebhooks.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockSpace.getRoles.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(getEditorInterface.mock.calls).toHaveLength(resultItemCount)
+      expect(response.data.contentTypes).toHaveLength(resultItemCount)
+      expect(response.data.entries).toHaveLength(resultItemCount)
+      expect(response.data.assets).toHaveLength(resultItemCount)
+      expect(response.data.locales).toHaveLength(resultItemCount)
+      expect(response.data.tags).toHaveLength(resultItemCount)
+      expect(response.data.webhooks).toHaveLength(resultItemCount)
+      expect(response.data.roles).toHaveLength(resultItemCount)
+      expect(response.data.editorInterfaces).toHaveLength(resultItemCount)
+    })
+})
+
 test('Skips webhooks & roles for non-master environments', () => {
   return getSpaceData({
     client: mockClient,


### PR DESCRIPTION
This PR adds the ability to export entries with the `inlcudeChanged` status.