### PR TITLE
chore(refactor): replace fs-extra with node fs standard library

### DIFF
--- a/lib/tasks/download-assets.js
+++ b/lib/tasks/download-assets.js
@@ -1,7 +1,7 @@
 import path from 'path'
 import Promise from 'bluebird'
 import figures from 'figures'
-import fs from 'fs-extra'
+import { createWriteStream, promises as fs } from 'fs'
 import fetch from 'node-fetch'
 import { pipeline } from 'stream'
 import { promisify } from 'util'
@@ -21,8 +21,8 @@ async function downloadAsset ({ url, directory }) {
   const localFile = path.join(directory, parsedUrl.host, parsedUrl.pathname)
 
   // ensure directory exists and create file stream
-  fs.mkdirsSync(path.dirname(localFile))
-  const file = fs.createWriteStream(localFile)
+  await fs.mkdir(path.dirname(localFile), { recursive: true })
+  const file = createWriteStream(localFile)
 
   // download asset
   const assetRequest = await fetch(url)

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "contentful-batch-libs": "^9.2.1",
         "contentful-management": "^10.0.0",
         "figures": "^3.2.0",
-        "fs-extra": "^10.0.0",
         "jsonwebtoken": "^8.5.1",
         "listr": "^0.14.1",
         "listr-update-renderer": "^0.5.0",
@@ -6849,6 +6848,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -6862,6 +6862,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
       "dependencies": {
         "universalify": "^2.0.0"
       },
@@ -6873,6 +6874,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+      "dev": true,
       "engines": {
         "node": ">= 10.0.0"
       }
@@ -7127,7 +7129,8 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
@@ -21449,6 +21452,7 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -21459,6 +21463,7 @@
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
           "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6",
             "universalify": "^2.0.0"
@@ -21467,7 +21472,8 @@
         "universalify": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+          "dev": true
         }
       }
     },
@@ -21667,7 +21673,8 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "dev": true
     },
     "handlebars": {
       "version": "4.7.7",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "contentful-batch-libs": "^9.2.1",
     "contentful-management": "^10.0.0",
     "figures": "^3.2.0",
-    "fs-extra": "^10.0.0",
     "jsonwebtoken": "^8.5.1",
     "listr": "^0.14.1",
     "listr-update-renderer": "^0.5.0",


### PR DESCRIPTION
- Replaces additional package `fs-extra` with node's standard library `fs`.