### PR TITLE
chore(deps): remove lodash

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,7 @@ import Table from 'cli-table3'
 import Listr from 'listr'
 import UpdateRenderer from 'listr-update-renderer'
 import VerboseRenderer from 'listr-verbose-renderer'
-import { startCase } from 'lodash'
+import startCase from 'lodash.startcase'
 import mkdirp from 'mkdirp'
 import moment from 'moment'
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "listr": "^0.14.1",
         "listr-update-renderer": "^0.5.0",
         "listr-verbose-renderer": "^0.6.0",
-        "lodash": "^4.17.10",
+        "lodash.startcase": "^4.4.0",
         "mkdirp": "^1.0.3",
         "moment": "^2.22.2",
         "node-fetch": "^2.6.7",
@@ -38,7 +38,6 @@
         "@babel/types": "^7.0.0",
         "@types/jest": "^27.0.2",
         "@typescript-eslint/eslint-plugin": "^5.22.0",
-        "babel-eslint": "^10.1.0",
         "babel-jest": "^28.0.0",
         "babel-plugin-add-module-exports": "^1.0.2",
         "cz-conventional-changelog": "^3.3.0",
@@ -4102,27 +4101,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-      "dev": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "peerDependencies": {
-        "eslint": ">= 4.12.1"
       }
     },
     "node_modules/babel-jest": {
@@ -11033,6 +11011,11 @@
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
+    },
+    "node_modules/lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg="
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -19541,20 +19524,6 @@
         }
       }
     },
-    "babel-eslint": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.1.0.tgz",
-      "integrity": "sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.7.0",
-        "@babel/traverse": "^7.7.0",
-        "@babel/types": "^7.7.0",
-        "eslint-visitor-keys": "^1.0.0",
-        "resolve": "^1.12.0"
-      }
-    },
     "babel-jest": {
       "version": "28.0.3",
       "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-28.0.3.tgz",
@@ -24694,6 +24663,11 @@
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
+    },
+    "lodash.startcase": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.startcase/-/lodash.startcase-4.4.0.tgz",
+      "integrity": "sha1-lDbjTtJgk+1/+uGTYUQ1CRXZrdg="
     },
     "lodash.truncate": {
       "version": "4.4.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "listr": "^0.14.1",
     "listr-update-renderer": "^0.5.0",
     "listr-verbose-renderer": "^0.6.0",
-    "lodash": "^4.17.10",
+    "lodash.startcase": "^4.4.0",
     "mkdirp": "^1.0.3",
     "moment": "^2.22.2",
     "node-fetch": "^2.6.7",

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -1,5 +1,3 @@
-import { times } from 'lodash/util'
-
 import getSpaceData from '../../../lib/tasks/get-space-data'
 
 const maxAllowedLimit = 100
@@ -9,11 +7,9 @@ function pagedResult (query, maxItems, mock = {}) {
   const { skip, limit } = query
   const cnt = maxItems - skip > limit ? limit : maxItems - skip
   return {
-    items: times(cnt, (n) => {
+    items: Array.from({ length: cnt}, (n) => {
       const id = n * skip + 1
-      return Object.assign({
-        sys: { id }
-      }, mock)
+      return Object.assign({ sys: { id }}, mock)
     }),
     total: maxItems
   }


### PR DESCRIPTION
## Details

**TLDR**: Removes `lodash` package to reduce package bloat.


Lodash is currently being used in 2 locations in this project:
1. In the test suite to generate `n` paginated entries (using `times` function)
2. In the results table to format headers (using `startCase`)

This PR replaces these locations by:
1. Using https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore, replaces `times` function with `Array.from`
2. Removes `lodash` import, replacing it with `lodash.startcase`. This will only import required files and not the whole `lodash` library.