### PR TITLE
chore(lint): fix eslint for *.test.js files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,10 @@
   ],
   "plugins": [
     "standard",
-    "promise"
-  ]
+    "promise",
+    "jest"
+  ],
+  "env": {
+    "jest/globals": true
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "eslint": "^7.2.0",
         "eslint-config-standard": "^16.0.1",
         "eslint-plugin-import": "^2.12.0",
-        "eslint-plugin-jest": "^26.0.0",
+        "eslint-plugin-jest": "^26.1.5",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-standard": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "eslint": "^7.2.0",
     "eslint-config-standard": "^16.0.1",
     "eslint-plugin-import": "^2.12.0",
-    "eslint-plugin-jest": "^26.0.0",
+    "eslint-plugin-jest": "^26.1.5",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-standard": "^5.0.0",

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -10,60 +10,22 @@ import {
   writeErrorLogFile
 } from 'contentful-batch-libs/dist/logging'
 
-import downloadAssets, { downloadAssetsMock } from '../../lib/tasks/download-assets'
+import { mockDownloadAssets } from './mocks/download-assets'
+import { mockGetSpaceData } from './mocks/get-space-data'
+
+import downloadAssets from '../../lib/tasks/download-assets'
 import getSpaceData from '../../lib/tasks/get-space-data'
 import initClient from '../../lib/tasks/init-client'
 import runContentfulExport from '../../lib/index'
 
-jest.mock('../../lib/tasks/download-assets', () => {
-  const downloadAssetsMock = jest.fn((ctx) => {
-    ctx.assetDownloads = {
-      successCount: 3,
-      warningCount: 2,
-      errorCount: 1
-    }
-    return Promise.resolve()
-  })
-  const downloadAssets = jest.fn(() => downloadAssetsMock)
-  downloadAssets.downloadAssetsMock = downloadAssetsMock
-  return downloadAssets
-})
-jest.mock('../../lib/tasks/get-space-data', () => jest.fn(() => {
-  const Listr = require('listr')
-  return new Listr([
-    {
-      title: 'mocked get full source space',
-      task: (ctx) => {
-        ctx.data = {
-          contentTypes: [],
-          entries: [],
-          assets: [
-            {
-              sys: {
-                id: 'someValidAsset'
-              },
-              fields: {
-                file: {
-                  'en-US': {
-                    url: '//images.contentful.com/kq9lln4hyr8s/2MTd2wBirYikEYkIIc0YSw/7aa4c06f3054996e45bb3f13964cb254/rocka-nutrition.png'
-                  }
-                }
-              }
-            },
-            {
-              sys: {
-                id: 'someBrokenAsset'
-              },
-              fields: {}
-            }
-          ],
-          locales: []
-        }
-      }
-    }
-  ])
-}))
-jest.mock('../../lib/tasks/init-client', () => jest.fn())
+jest.spyOn(global.console, 'log')
+jest.mock('../../lib/tasks/init-client')
+jest.mock('../../lib/tasks/download-assets', () => jest.fn(() => mockDownloadAssets))
+jest.mock('../../lib/tasks/get-space-data', () => jest.fn(mockGetSpaceData))
+
+jest.mock('fs', () => ({ access: jest.fn((path, cb) => cb()) }))
+jest.mock('mkdirp', () => jest.fn())
+jest.mock('bfj', () => ({ write: jest.fn().mockResolvedValue() }))
 jest.mock('contentful-batch-libs/dist/logging', () => ({
   setupLogging: jest.fn(),
   displayErrorLog: jest.fn(),
@@ -75,14 +37,6 @@ jest.mock('contentful-batch-libs/dist/logging', () => ({
     throw multiError
   })
 }))
-jest.mock('fs', () => ({
-  access: jest.fn((path, cb) => cb())
-}))
-jest.mock('mkdirp', (path) => jest.fn())
-jest.mock('bfj', () => ({
-  write: jest.fn(() => Promise.resolve())
-}))
-jest.spyOn(global.console, 'log')
 
 afterEach(() => {
   initClient.mockClear()
@@ -94,129 +48,117 @@ afterEach(() => {
   bfj.write.mockClear()
   writeErrorLogFile.mockClear()
   downloadAssets.mockClear()
-  downloadAssetsMock.mockClear()
   global.console.log.mockClear()
 })
 
-test('Runs Contentful Export with default config', () => {
-  return runContentfulExport({
+test('Runs Contentful Export with default config', async () => {
+  await runContentfulExport({
     errorLogFile: 'errorlogfile',
     spaceId: 'someSpaceId',
     managementToken: 'someManagementToken'
   })
-    .then((returnedData) => {
-      expect(initClient.mock.calls).toHaveLength(1)
-      expect(getSpaceData.mock.calls).toHaveLength(1)
-      expect(setupLogging.mock.calls).toHaveLength(1)
-      expect(downloadAssets.mock.calls).toHaveLength(1)
-      expect(downloadAssetsMock.mock.calls).toHaveLength(0)
-      expect(displayErrorLog.mock.calls).toHaveLength(1)
-      expect(fs.access.mock.calls).toHaveLength(1)
-      expect(mkdirp.mock.calls).toHaveLength(1)
-      expect(bfj.write.mock.calls).toHaveLength(1)
-      expect(writeErrorLogFile.mock.calls).toHaveLength(0)
-      const exportedTable = global.console.log.mock.calls.find((call) => call[0].match(/Exported entities/))
-      expect(exportedTable).not.toBeUndefined()
-      expect(exportedTable[0]).toMatch(/Exported entities/)
-      expect(exportedTable[0]).toMatch(/Content Types.+0/)
-      expect(exportedTable[0]).toMatch(/Entries.+0/)
-      expect(exportedTable[0]).toMatch(/Assets.+2/)
-      expect(exportedTable[0]).toMatch(/Locales.+0/)
-      const assetsTable = global.console.log.mock.calls.find((call) => call[0].match(/Asset file download results/))
-      expect(assetsTable).toBeUndefined()
-    })
+
+  expect(initClient.mock.calls).toHaveLength(1)
+  expect(getSpaceData.mock.calls).toHaveLength(1)
+  expect(setupLogging.mock.calls).toHaveLength(1)
+  expect(downloadAssets.mock.calls).toHaveLength(1)
+  expect(displayErrorLog.mock.calls).toHaveLength(1)
+  expect(fs.access.mock.calls).toHaveLength(1)
+  expect(mkdirp.mock.calls).toHaveLength(1)
+  expect(bfj.write.mock.calls).toHaveLength(1)
+  expect(writeErrorLogFile.mock.calls).toHaveLength(0)
+  const exportedTable = global.console.log.mock.calls.find((call) => call[0].match(/Exported entities/))
+  expect(exportedTable).not.toBeUndefined()
+  expect(exportedTable[0]).toMatch(/Exported entities/)
+  expect(exportedTable[0]).toMatch(/Content Types.+0/)
+  expect(exportedTable[0]).toMatch(/Entries.+0/)
+  expect(exportedTable[0]).toMatch(/Assets.+2/)
+  expect(exportedTable[0]).toMatch(/Locales.+0/)
+  const assetsTable = global.console.log.mock.calls.find((call) => call[0].match(/Asset file download results/))
+  expect(assetsTable).toBeUndefined()
 })
 
-test('Runs Contentful Export and downloads assets', () => {
-  return runContentfulExport({
+test('Runs Contentful Export and downloads assets', async () => {
+  await runContentfulExport({
     errorLogFile: 'errorlogfile',
     spaceId: 'someSpaceId',
     managementToken: 'someManagementToken',
     downloadAssets: true
   })
-    .then((returnedData) => {
-      expect(initClient.mock.calls).toHaveLength(1)
-      expect(getSpaceData.mock.calls).toHaveLength(1)
-      expect(setupLogging.mock.calls).toHaveLength(1)
-      expect(downloadAssets.mock.calls).toHaveLength(1)
-      expect(downloadAssetsMock.mock.calls).toHaveLength(1)
-      expect(displayErrorLog.mock.calls).toHaveLength(1)
-      expect(fs.access.mock.calls).toHaveLength(1)
-      expect(mkdirp.mock.calls).toHaveLength(1)
-      expect(bfj.write.mock.calls).toHaveLength(1)
-      expect(writeErrorLogFile.mock.calls).toHaveLength(0)
-      const exportedTable = global.console.log.mock.calls.find((call) => call[0].match(/Exported entities/))
-      expect(exportedTable).not.toBeUndefined()
-      expect(exportedTable[0]).toMatch(/Exported entities/)
-      expect(exportedTable[0]).toMatch(/Content Types.+0/)
-      expect(exportedTable[0]).toMatch(/Entries.+0/)
-      expect(exportedTable[0]).toMatch(/Assets.+2/)
-      expect(exportedTable[0]).toMatch(/Locales.+0/)
-      const assetsTable = global.console.log.mock.calls.find((call) => call[0].match(/Asset file download results/))
-      expect(assetsTable).not.toBeUndefined()
-      expect(assetsTable[0]).toMatch(/Asset file download results/)
-      expect(assetsTable[0]).toMatch(/Successful.+3/)
-      expect(assetsTable[0]).toMatch(/Warnings.+2/)
-      expect(assetsTable[0]).toMatch(/Errors.+1/)
-    })
+
+  expect(initClient.mock.calls).toHaveLength(1)
+  expect(getSpaceData.mock.calls).toHaveLength(1)
+  expect(setupLogging.mock.calls).toHaveLength(1)
+  expect(downloadAssets.mock.calls).toHaveLength(1)
+  expect(displayErrorLog.mock.calls).toHaveLength(1)
+  expect(fs.access.mock.calls).toHaveLength(1)
+  expect(mkdirp.mock.calls).toHaveLength(1)
+  expect(bfj.write.mock.calls).toHaveLength(1)
+  expect(writeErrorLogFile.mock.calls).toHaveLength(0)
+  const exportedTable = global.console.log.mock.calls.find((call) => call[0].match(/Exported entities/))
+  expect(exportedTable).not.toBeUndefined()
+  expect(exportedTable[0]).toMatch(/Exported entities/)
+  expect(exportedTable[0]).toMatch(/Content Types.+0/)
+  expect(exportedTable[0]).toMatch(/Entries.+0/)
+  expect(exportedTable[0]).toMatch(/Assets.+2/)
+  expect(exportedTable[0]).toMatch(/Locales.+0/)
+  const assetsTable = global.console.log.mock.calls.find((call) => call[0].match(/Asset file download results/))
+  expect(assetsTable).not.toBeUndefined()
+  expect(assetsTable[0]).toMatch(/Asset file download results/)
+  expect(assetsTable[0]).toMatch(/Successful.+3/)
+  expect(assetsTable[0]).toMatch(/Warnings.+2/)
+  expect(assetsTable[0]).toMatch(/Errors.+1/)
 })
 
-test('Creates a valid and correct opts object', () => {
+test('Creates a valid and correct opts object', async () => {
   const errorLogFile = 'errorlogfile'
-  const exampleConfig = require('../../example-config.test.json')
+  const { default: exampleConfig } = await import('../../example-config.test.json')
 
-  return runContentfulExport({
+  await runContentfulExport({
     errorLogFile,
     config: resolve(__dirname, '..', '..', 'example-config.test.json')
   })
-    .then(() => {
-      expect(initClient.mock.calls[0][0].skipContentModel).toBeFalsy()
-      expect(initClient.mock.calls[0][0].skipEditorInterfaces).toBeFalsy()
-      expect(initClient.mock.calls[0][0].errorLogFile).toBe(resolve(process.cwd(), errorLogFile))
-      expect(initClient.mock.calls[0][0].spaceId).toBe(exampleConfig.spaceId)
-      expect(initClient.mock.calls).toHaveLength(1)
-      expect(getSpaceData.mock.calls).toHaveLength(1)
-      expect(setupLogging.mock.calls).toHaveLength(1)
-      expect(downloadAssets.mock.calls).toHaveLength(1)
-      expect(downloadAssetsMock.mock.calls).toHaveLength(0)
-      expect(displayErrorLog.mock.calls).toHaveLength(1)
-      expect(fs.access.mock.calls).toHaveLength(1)
-      expect(mkdirp.mock.calls).toHaveLength(1)
-      expect(bfj.write.mock.calls).toHaveLength(1)
-      expect(writeErrorLogFile.mock.calls).toHaveLength(0)
-      const exportedTable = global.console.log.mock.calls.find((call) => call[0].match(/Exported entities/))
-      expect(exportedTable).not.toBeUndefined()
-      expect(exportedTable[0]).toMatch(/Exported entities/)
-      expect(exportedTable[0]).toMatch(/Content Types.+0/)
-      expect(exportedTable[0]).toMatch(/Entries.+0/)
-      expect(exportedTable[0]).toMatch(/Assets.+2/)
-      expect(exportedTable[0]).toMatch(/Locales.+0/)
-    })
+
+  expect(initClient.mock.calls[0][0].skipContentModel).toBeFalsy()
+  expect(initClient.mock.calls[0][0].skipEditorInterfaces).toBeFalsy()
+  expect(initClient.mock.calls[0][0].errorLogFile).toBe(resolve(process.cwd(), errorLogFile))
+  expect(initClient.mock.calls[0][0].spaceId).toBe(exampleConfig.spaceId)
+  expect(initClient.mock.calls).toHaveLength(1)
+  expect(getSpaceData.mock.calls).toHaveLength(1)
+  expect(setupLogging.mock.calls).toHaveLength(1)
+  expect(downloadAssets.mock.calls).toHaveLength(1)
+  expect(displayErrorLog.mock.calls).toHaveLength(1)
+  expect(fs.access.mock.calls).toHaveLength(1)
+  expect(mkdirp.mock.calls).toHaveLength(1)
+  expect(bfj.write.mock.calls).toHaveLength(1)
+  expect(writeErrorLogFile.mock.calls).toHaveLength(0)
+  const exportedTable = global.console.log.mock.calls.find((call) => call[0].match(/Exported entities/))
+  expect(exportedTable).not.toBeUndefined()
+  expect(exportedTable[0]).toMatch(/Exported entities/)
+  expect(exportedTable[0]).toMatch(/Content Types.+0/)
+  expect(exportedTable[0]).toMatch(/Entries.+0/)
+  expect(exportedTable[0]).toMatch(/Assets.+2/)
+  expect(exportedTable[0]).toMatch(/Locales.+0/)
 })
 
-test('Run Contentful export fails due to rejection', () => {
+test('Run Contentful export fails due to rejection', async () => {
   const rejectError = new Error()
   rejectError.request = { uri: 'erroruri' }
   getSpaceData.mockImplementation(() => Promise.reject(rejectError))
 
-  return runContentfulExport({
+  await expect(runContentfulExport({
     errorLogFile: 'errorlogfile',
     spaceId: 'someSpaceId',
     managementToken: 'someManagementToken'
-  })
-    .then(() => {
-      throw new Error('should not resolve')
-    })
-    .catch(() => {
-      expect(initClient.mock.calls).toHaveLength(1)
-      expect(getSpaceData.mock.calls).toHaveLength(1)
-      expect(setupLogging.mock.calls).toHaveLength(1)
-      expect(downloadAssets.mock.calls).toHaveLength(1)
-      expect(downloadAssetsMock.mock.calls).toHaveLength(0)
-      expect(displayErrorLog.mock.calls).toHaveLength(1)
-      expect(fs.access.mock.calls).toHaveLength(0)
-      expect(mkdirp.mock.calls).toHaveLength(0)
-      expect(bfj.write.mock.calls).toHaveLength(0)
-      expect(writeErrorLogFile.mock.calls).toHaveLength(1)
-    })
+  })).rejects.toThrow()
+
+  expect(initClient.mock.calls).toHaveLength(1)
+  expect(getSpaceData.mock.calls).toHaveLength(1)
+  expect(setupLogging.mock.calls).toHaveLength(1)
+  expect(downloadAssets.mock.calls).toHaveLength(1)
+  expect(displayErrorLog.mock.calls).toHaveLength(1)
+  expect(fs.access.mock.calls).toHaveLength(0)
+  expect(mkdirp.mock.calls).toHaveLength(0)
+  expect(bfj.write.mock.calls).toHaveLength(0)
+  expect(writeErrorLogFile.mock.calls).toHaveLength(1)
 })

--- a/test/unit/mocks/download-assets.js
+++ b/test/unit/mocks/download-assets.js
@@ -1,0 +1,7 @@
+export const mockDownloadAssets = async (ctx) => {
+  ctx.assetDownloads = {
+    successCount: 3,
+    warningCount: 2,
+    errorCount: 1
+  }
+}

--- a/test/unit/mocks/get-space-data.js
+++ b/test/unit/mocks/get-space-data.js
@@ -1,0 +1,32 @@
+import Listr from 'listr'
+
+export const mockGetSpaceData = () => {
+  return new Listr([
+    {
+      title: 'mocked get full source space',
+      task: (ctx) => {
+        ctx.data = {
+          contentTypes: [],
+          entries: [],
+          assets: [
+            {
+              sys: { id: 'someValidAsset' },
+              fields: {
+                file: {
+                  'en-US': {
+                    url: '//images.contentful.com/kq9lln4hyr8s/2MTd2wBirYikEYkIIc0YSw/7aa4c06f3054996e45bb3f13964cb254/rocka-nutrition.png'
+                  }
+                }
+              }
+            },
+            {
+              sys: { id: 'someBrokenAsset' },
+              fields: {}
+            }
+          ],
+          locales: []
+        }
+      }
+    }
+  ])
+}

--- a/test/unit/parseOptions.test.js
+++ b/test/unit/parseOptions.test.js
@@ -29,13 +29,11 @@ test('parseOptions sets requires managementToken', () => {
   ).toThrow('The `managementToken` option is required.')
 })
 
-test('parseOptions sets correct default options', () => {
-  const version = require(resolve(basePath, 'package.json')).version
+test('parseOptions sets correct default options', async () => {
+  const { default: packageJson } = await import(resolve(basePath, 'package.json'))
+  const version = packageJson.version
 
-  const options = parseOptions({
-    spaceId,
-    managementToken
-  })
+  const options = parseOptions({ spaceId, managementToken })
 
   const contentFileNamePattern = `contentful-export-${spaceId}-master-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}\\.json`
   const errorFileNamePattern = `contentful-export-error-log-${spaceId}-master-[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}\\.json`
@@ -62,13 +60,11 @@ test('parseOptions sets correct default options', () => {
   expect(options.deliveryToken).toBeUndefined()
 })
 
-test('parseOption accepts config file', () => {
+test('parseOption accepts config file', async () => {
   const configFileName = 'example-config.test.json'
-  const config = require(resolve(basePath, configFileName))
+  const { default: config } = await import(resolve(basePath, configFileName))
 
-  const options = parseOptions({
-    config: configFileName
-  })
+  const options = parseOptions({ config: configFileName })
   Object.keys(config).forEach((key) => {
     expect(options[key]).toBe(config[key])
   })


### PR DESCRIPTION
With the latest lint changes, I noticed the `*.test.js` files no longer were being linted. This PR reintroduces linting for test files, and fixes any issues that arose.

I took this opportunity to tidy up the main unit test file, by:
- Moving large mocked objects into a new `mocks` directory
- Converting tests to async/await syntax (moving away from promise chains)