### PR TITLE
chore(deps): replace moment with date-fns

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,8 @@ import UpdateRenderer from 'listr-update-renderer'
 import VerboseRenderer from 'listr-verbose-renderer'
 import startCase from 'lodash.startcase'
 import mkdirp from 'mkdirp'
-import moment from 'moment'
+import differenceInSeconds from 'date-fns/differenceInSeconds'
+import formatDistance from 'date-fns/formatDistance'
 
 import { wrapTask } from 'contentful-batch-libs/dist/listr'
 import {
@@ -156,8 +157,9 @@ export default function runContentfulExport (params) {
         console.log(downloadsTable.toString())
       }
 
-      const durationHuman = options.startTime.fromNow(true)
-      const durationSeconds = moment().diff(options.startTime, 'seconds')
+      const endTime = new Date()
+      const durationHuman = formatDistance(endTime, options.startTime)
+      const durationSeconds = differenceInSeconds(endTime, options.startTime)
 
       console.log(`The export took ${durationHuman} (${durationSeconds}s)`)
       if (options.saveFile) {

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 
-import moment from 'moment'
+import format from 'date-fns/format'
 
 import { getHeadersConfig } from './utils/headers'
 import { proxyStringToObject, agentFromProxy } from 'contentful-batch-libs/dist/proxy'
@@ -53,13 +53,13 @@ export default function parseOptions (params) {
     throw new Error('Please provide the proxy config in the following format:\nhost:port or user:password@host:port')
   }
 
-  options.startTime = moment()
-  options.contentFile = options.contentFile || `contentful-export-${options.spaceId}-${options.environmentId}-${options.startTime.format('YYYY-MM-DDTHH-mm-SS')}.json`
+  options.startTime = new Date()
+  options.contentFile = options.contentFile || `contentful-export-${options.spaceId}-${options.environmentId}-${format(options.startTime, "yyyy-MM-dd'T'HH-mm-ss")}.json`
 
   options.logFilePath = resolve(options.exportDir, options.contentFile)
 
   if (!options.errorLogFile) {
-    options.errorLogFile = resolve(options.exportDir, `contentful-export-error-log-${options.spaceId}-${options.environmentId}-${options.startTime.format('YYYY-MM-DDTHH-mm-SS')}.json`)
+    options.errorLogFile = resolve(options.exportDir, `contentful-export-error-log-${options.spaceId}-${options.environmentId}-${format(options.startTime, "yyyy-MM-dd'T'HH-mm-ss")}.json`)
   } else {
     options.errorLogFile = resolve(process.cwd(), options.errorLogFile)
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "contentful": "^9.0.0",
         "contentful-batch-libs": "^9.2.1",
         "contentful-management": "^10.0.0",
+        "date-fns": "^2.28.0",
         "figures": "^3.2.0",
         "jsonwebtoken": "^8.5.1",
         "listr": "^0.14.1",
@@ -22,7 +23,6 @@
         "listr-verbose-renderer": "^0.6.0",
         "lodash.startcase": "^4.4.0",
         "mkdirp": "^1.0.3",
-        "moment": "^2.22.2",
         "node-fetch": "^2.6.7",
         "yargs": "^17.1.1"
       },
@@ -5386,9 +5386,16 @@
       }
     },
     "node_modules/date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/dateformat": {
       "version": "3.0.3",
@@ -10816,18 +10823,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/listr-verbose-renderer/node_modules/date-fns": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw==",
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
-    },
     "node_modules/listr-verbose-renderer/node_modules/figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -10873,6 +10868,11 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/listr/node_modules/date-fns": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "node_modules/listr/node_modules/figures": {
       "version": "2.0.0",
@@ -20512,9 +20512,9 @@
       }
     },
     "date-fns": {
-      "version": "1.30.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
-      "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
+      "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
     },
     "dateformat": {
       "version": "3.0.3",
@@ -24434,6 +24434,11 @@
             "supports-color": "^5.3.0"
           }
         },
+        "date-fns": {
+          "version": "1.30.1",
+          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.30.1.tgz",
+          "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
+        },
         "figures": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -24540,11 +24545,6 @@
             "escape-string-regexp": "^1.0.5",
             "supports-color": "^5.3.0"
           }
-        },
-        "date-fns": {
-          "version": "2.28.0",
-          "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.28.0.tgz",
-          "integrity": "sha512-8d35hViGYx/QH0icHYCeLmsLmMUheMmTyV9Fcm6gvNwdw31yXXH+O85sOBJ+OLnLQMKZowvpKb6FgMIQjcpvQw=="
         },
         "figures": {
           "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "contentful": "^9.0.0",
     "contentful-batch-libs": "^9.2.1",
     "contentful-management": "^10.0.0",
+    "date-fns": "^2.28.0",
     "figures": "^3.2.0",
     "jsonwebtoken": "^8.5.1",
     "listr": "^0.14.1",
@@ -56,7 +57,6 @@
     "listr-verbose-renderer": "^0.6.0",
     "lodash.startcase": "^4.4.0",
     "mkdirp": "^1.0.3",
-    "moment": "^2.22.2",
     "node-fetch": "^2.6.7",
     "yargs": "^17.1.1"
   },

--- a/test/unit/parseOptions.test.js
+++ b/test/unit/parseOptions.test.js
@@ -1,6 +1,5 @@
 import { basename, isAbsolute, resolve, sep } from 'path'
 
-import moment from 'moment'
 import HttpsProxyAgent from 'https-proxy-agent'
 
 import parseOptions from '../../lib/parseOptions'
@@ -55,7 +54,7 @@ test('parseOptions sets correct default options', async () => {
   expect(options.skipRoles).toBe(false)
   expect(options.skipWebhooks).toBe(false)
   expect(options.spaceId).toBe(spaceId)
-  expect(options.startTime).toBeInstanceOf(moment)
+  expect(options.startTime).toBeInstanceOf(Date)
   expect(options.useVerboseRenderer).toBe(false)
   expect(options.deliveryToken).toBeUndefined()
 })


### PR DESCRIPTION
Moment.js is a great library however due to the way it is packaged, it is quite large to install and causes package bloat. This PR replaces moment.js with another popular date parsing library [date-fns](https://www.npmjs.com/package/date-fns). Taken with a grain of salt, it seems like this will reduce package size by a significant amount whilst improving performance (see supporting [article](https://blog.bitsrc.io/date-fns-vs-momentjs-9833f7463751#:~:text=MomentJS%20package%20size%20is%20around,package%20size%20is%20300%20Bytes.)).


