### PR TITLE
fix: change the type of max-allowed-limit from boolean to number

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -16,7 +16,7 @@ export interface Options {
   limit?: number;
   managementApplication?: string;
   managementFeature?: string;
-  maxAllowedLimit?: boolean;
+  maxAllowedLimit?: number;
   proxy?: string;
   queryEntries?: string[];
   queryAssets?: string[];


### PR DESCRIPTION
Fix to change the type of `maxAllowedLimit` from boolean to number