### PR TITLE
chore(deps): update contentful batch libs to latest

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,12 +11,12 @@ import mkdirp from 'mkdirp'
 import differenceInSeconds from 'date-fns/differenceInSeconds'
 import formatDistance from 'date-fns/formatDistance'
 
-import { wrapTask } from 'contentful-batch-libs/dist/listr'
 import {
   setupLogging,
   displayErrorLog,
+  wrapTask,
   writeErrorLogFile
-} from 'contentful-batch-libs/dist/logging'
+} from 'contentful-batch-libs'
 
 import downloadAssets from './tasks/download-assets'
 import getSpaceData from './tasks/get-space-data'

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -1,14 +1,10 @@
-import { resolve } from 'path'
-
+import { addSequenceHeader, agentFromProxy, proxyStringToObject } from 'contentful-batch-libs'
 import format from 'date-fns/format'
-
-import { getHeadersConfig } from './utils/headers'
-import { proxyStringToObject, agentFromProxy } from 'contentful-batch-libs/dist/proxy'
-import addSequenceHeader from 'contentful-batch-libs/dist/add-sequence-header'
+import { resolve } from 'path'
+import qs from 'querystring'
 
 import { version } from '../package'
-
-import qs from 'querystring'
+import { getHeadersConfig } from './utils/headers'
 
 export default function parseOptions (params) {
   const defaultOptions = {

--- a/lib/tasks/download-assets.js
+++ b/lib/tasks/download-assets.js
@@ -1,12 +1,12 @@
-import path from 'path'
 import Promise from 'bluebird'
+import { getEntityName } from 'contentful-batch-libs'
 import figures from 'figures'
 import { createWriteStream, promises as fs } from 'fs'
 import fetch from 'node-fetch'
+import path from 'path'
 import { pipeline } from 'stream'
 import { promisify } from 'util'
 import { calculateExpiryTimestamp, isEmbargoedAsset, signUrl } from '../utils/embargoedAssets'
-import getEntityName from 'contentful-batch-libs/dist/get-entity-name'
 
 const streamPipeline = promisify(pipeline)
 

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -1,9 +1,7 @@
 import Promise from 'bluebird'
+import { logEmitter, wrapTask } from 'contentful-batch-libs'
 import Listr from 'listr'
 import verboseRenderer from 'listr-verbose-renderer'
-
-import { wrapTask } from 'contentful-batch-libs/dist/listr'
-import { logEmitter } from 'contentful-batch-libs/dist/logging'
 
 const MAX_ALLOWED_LIMIT = 1000
 let pageLimit = MAX_ALLOWED_LIMIT

--- a/lib/tasks/init-client.js
+++ b/lib/tasks/init-client.js
@@ -1,7 +1,6 @@
-import { createClient as createCmaClient } from 'contentful-management'
 import { createClient as createCdaClient } from 'contentful'
-
-import { logEmitter } from 'contentful-batch-libs/dist/logging'
+import { logEmitter } from 'contentful-batch-libs'
+import { createClient as createCmaClient } from 'contentful-management'
 
 function logHandler (level, data) {
   logEmitter.emit(level, data)

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "bluebird": "^3.3.3",
         "cli-table3": "^0.6.0",
         "contentful": "^9.0.0",
-        "contentful-batch-libs": "^9.2.1",
+        "contentful-batch-libs": "^9.3.0",
         "contentful-management": "^10.0.0",
         "date-fns": "^2.28.0",
         "figures": "^3.2.0",
@@ -2022,9 +2022,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "version": "13.14.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.14.0.tgz",
+      "integrity": "sha512-ERO68sOYwm5UuLvSJTY7w7NP2c8S4UcXs3X1GBX8cwOr+ShOcDBbCY5mH4zxz0jsYCdJ8ve8Mv9n2YGJMB1aeg==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -5307,14 +5307,14 @@
       }
     },
     "node_modules/contentful-batch-libs": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/contentful-batch-libs/-/contentful-batch-libs-9.2.2.tgz",
-      "integrity": "sha512-tbPliyNiU3KC8+3DbYesP63jBICL2NyIxm8o6LeBc9mGXfCM1HGlhLWyof/TLyrR7gwTcxcUh05Dv7pehYDG6Q==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/contentful-batch-libs/-/contentful-batch-libs-9.3.0.tgz",
+      "integrity": "sha512-sC633xVOY8wwFV43A1cxozdoRCw4Opg7OqTPUsKoS9XpAFqPj85ZOqzhfAwpVzgILwAGRYFGPbt0xgR1tVeByA==",
       "dependencies": {
         "bfj": "^7.0.2",
         "figures": "^3.2.0",
         "https-proxy-agent": "^3.0.0",
-        "lodash": "^4.17.21",
+        "lodash.clonedeep": "^4.5.0",
         "moment": "^2.29.1",
         "uuid": "^8.3.2"
       },
@@ -6531,9 +6531,9 @@
       }
     },
     "node_modules/eslint/node_modules/globals": {
-      "version": "13.13.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-      "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+      "version": "13.14.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.14.0.tgz",
+      "integrity": "sha512-ERO68sOYwm5UuLvSJTY7w7NP2c8S4UcXs3X1GBX8cwOr+ShOcDBbCY5mH4zxz0jsYCdJ8ve8Mv9n2YGJMB1aeg==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -11131,7 +11131,8 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "node_modules/lodash.capitalize": {
       "version": "4.2.1",
@@ -11142,8 +11143,7 @@
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -18152,9 +18152,9 @@
           }
         },
         "globals": {
-          "version": "13.13.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-          "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+          "version": "13.14.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.14.0.tgz",
+          "integrity": "sha512-ERO68sOYwm5UuLvSJTY7w7NP2c8S4UcXs3X1GBX8cwOr+ShOcDBbCY5mH4zxz0jsYCdJ8ve8Mv9n2YGJMB1aeg==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -20606,14 +20606,14 @@
       }
     },
     "contentful-batch-libs": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/contentful-batch-libs/-/contentful-batch-libs-9.2.2.tgz",
-      "integrity": "sha512-tbPliyNiU3KC8+3DbYesP63jBICL2NyIxm8o6LeBc9mGXfCM1HGlhLWyof/TLyrR7gwTcxcUh05Dv7pehYDG6Q==",
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/contentful-batch-libs/-/contentful-batch-libs-9.3.0.tgz",
+      "integrity": "sha512-sC633xVOY8wwFV43A1cxozdoRCw4Opg7OqTPUsKoS9XpAFqPj85ZOqzhfAwpVzgILwAGRYFGPbt0xgR1tVeByA==",
       "requires": {
         "bfj": "^7.0.2",
         "figures": "^3.2.0",
         "https-proxy-agent": "^3.0.0",
-        "lodash": "^4.17.21",
+        "lodash.clonedeep": "^4.5.0",
         "moment": "^2.29.1",
         "uuid": "^8.3.2"
       },
@@ -21342,9 +21342,9 @@
           "dev": true
         },
         "globals": {
-          "version": "13.13.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
-          "integrity": "sha512-EQ7Q18AJlPwp3vUDL4mKA0KXrXyNIQyWon6T6XQiBQF0XHvRsiCSrWmmeATpUzdJN2HhWZU6Pdl0a9zdep5p6A==",
+          "version": "13.14.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-13.14.0.tgz",
+          "integrity": "sha512-ERO68sOYwm5UuLvSJTY7w7NP2c8S4UcXs3X1GBX8cwOr+ShOcDBbCY5mH4zxz0jsYCdJ8ve8Mv9n2YGJMB1aeg==",
           "dev": true,
           "requires": {
             "type-fest": "^0.20.2"
@@ -24897,7 +24897,8 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.capitalize": {
       "version": "4.2.1",
@@ -24908,8 +24909,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "bluebird": "^3.3.3",
     "cli-table3": "^0.6.0",
     "contentful": "^9.0.0",
-    "contentful-batch-libs": "^9.2.1",
+    "contentful-batch-libs": "^9.3.0",
     "contentful-management": "^10.0.0",
     "date-fns": "^2.28.0",
     "figures": "^3.2.0",

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -8,7 +8,7 @@ import {
   setupLogging,
   displayErrorLog,
   writeErrorLogFile
-} from 'contentful-batch-libs/dist/logging'
+} from 'contentful-batch-libs'
 
 import { mockDownloadAssets } from './mocks/download-assets'
 import { mockGetSpaceData } from './mocks/get-space-data'

--- a/test/unit/parseOptions.test.js
+++ b/test/unit/parseOptions.test.js
@@ -1,7 +1,5 @@
-import { basename, isAbsolute, resolve, sep } from 'path'
-
 import HttpsProxyAgent from 'https-proxy-agent'
-
+import { basename, isAbsolute, resolve, sep } from 'path'
 import parseOptions from '../../lib/parseOptions'
 
 const spaceId = 'foo'

--- a/test/unit/tasks/init-client.test.js
+++ b/test/unit/tasks/init-client.test.js
@@ -2,7 +2,7 @@ import initClient from '../../../lib/tasks/init-client'
 
 import contentfulManagement from 'contentful-management'
 import contentful from 'contentful'
-import { logEmitter } from 'contentful-batch-libs/dist/logging'
+import { logEmitter } from 'contentful-batch-libs'
 
 jest.mock('contentful-management', () => {
   return {
@@ -16,7 +16,7 @@ jest.mock('contentful', () => {
   }
 })
 
-jest.mock('contentful-batch-libs/dist/logging', () => {
+jest.mock('contentful-batch-libs', () => {
   return {
     logEmitter: {
       emit: jest.fn()

--- a/test/unit/utils/headers.test.js
+++ b/test/unit/utils/headers.test.js
@@ -1,4 +1,4 @@
-const { getHeadersConfig } = require('../../../lib/utils/headers')
+import { getHeadersConfig } from '../../../lib/utils/headers'
 
 test('getHeadersConfig returns empty object when value is undefined', () => {
   expect(getHeadersConfig(undefined)).toEqual({})


### PR DESCRIPTION
- Updates `contentful-batch-libs ` to latest
- General `import` statement fixes. This includes auto-formatting the ordering (VSCode using ALT+SHIFT+O, or CMD+SHIFT+O)