### PR TITLE
feat(public-tags): export public tags

### DIFF
--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -68,8 +68,7 @@ export default function getFullSourceSpace ({
           .catch(() => {
             ctx.data.tags = []
           })
-      }),
-      skip: () => cdaClient
+      })
     },
     {
       title: 'Fetching editor interfaces data',

--- a/test/integration/export-lib.test.js
+++ b/test/integration/export-lib.test.js
@@ -38,7 +38,7 @@ test('It should export space when used as a library', () => {
       expect(content.entries).toHaveLength(4)
       expect(content.assets).toHaveLength(4)
       expect(content.locales).toHaveLength(1)
-      expect(content.tags).toHaveLength(3)
+      expect(content.tags).toHaveLength(4)
       expect(content.webhooks).toHaveLength(0)
       expect(content.roles).toHaveLength(7)
       // make sure entries are delivered from CMA
@@ -59,7 +59,7 @@ test('It should export environment when used as a library', () => {
       expect(content.entries).toHaveLength(4)
       expect(content.assets).toHaveLength(4)
       expect(content.locales).toHaveLength(1)
-      expect(content.tags).toHaveLength(1)
+      expect(content.tags).toHaveLength(2)
       expect(content).not.toHaveProperty('webhooks')
       expect(content).not.toHaveProperty('roles')
     })
@@ -78,9 +78,7 @@ test('It should export space when used as a library, with deliveryToken', () => 
       expect(content.entries).toHaveLength(4)
       expect(content.assets).toHaveLength(4)
       expect(content.locales).toHaveLength(1)
-      // TODO Tag one entry with one public tag in test space. Add one
-      // public and one private tag to the test setup.
-      expect(content.tags).toHaveLength(3)
+      expect(content.tags).toHaveLength(4)
       expect(content.webhooks).toHaveLength(0)
       expect(content.roles).toHaveLength(7)
       // entries returned from CDN don't have this property

--- a/test/integration/export-lib.test.js
+++ b/test/integration/export-lib.test.js
@@ -78,7 +78,9 @@ test('It should export space when used as a library, with deliveryToken', () => 
       expect(content.entries).toHaveLength(4)
       expect(content.assets).toHaveLength(4)
       expect(content.locales).toHaveLength(1)
-      expect(content.tags).toBeUndefined()
+      // TODO Tag one entry with one public tag in test space. Add one
+      // public and one private tag to the test setup.
+      expect(content.tags).toHaveLength(3)
       expect(content.webhooks).toHaveLength(0)
       expect(content.roles).toHaveLength(7)
       // entries returned from CDN don't have this property


### PR DESCRIPTION
When passing `deliveryToken` as option and internally using the cdaClient, we don't return even public tags. This should be adjusted, as it causes imports based on public tags to fail.

### To be discussed
- Should we export all tags here even if deliveryToken is passed in?
- Should we only export public tags?

Starting points to look at:
- Initialization of cdaClient: https://github.com/contentful/contentful-export/blob/feat%2Fexport-public-tags/lib/tasks/init-client.js#L25
- Introduction of tags on the cma: https://github.com/contentful/contentful-export/commit/e79a35caf7b4dff6d9864cdbf7280ded89486b8c