### PR TITLE
fix(asset-cache): embargoed assets cache calculation

### DIFF
--- a/lib/utils/embargoedAssets.js
+++ b/lib/utils/embargoedAssets.js
@@ -17,11 +17,14 @@ function createAssetKey (host, accessToken, spaceId, environmentId, expiresAtMs)
   })
 }
 
-async function createCachedAssetKey (host, accessToken, spaceId, environmentId, minExpiresAtMs) {
+export const shouldCreateNewCacheItem = (cacheItem, currentExpiresAtMs) =>
+  !cacheItem || currentExpiresAtMs - cacheItem.expiresAtMs < SIX_HOURS_IN_MS
+
+async function createCachedAssetKey(host, accessToken, spaceId, environmentId, minExpiresAtMs) {
   const cacheKey = `${host}:${spaceId}:${environmentId}`
   let cacheItem = assetKeyCache.get(cacheKey)
 
-  if (!cacheItem || cacheItem.expiresAtMs < minExpiresAtMs) {
+  if (shouldCreateNewCacheItem(cacheItem, minExpiresAtMs)) {
     const expiresAtMs = calculateExpiryTimestamp()
 
     if (minExpiresAtMs > expiresAtMs) {

--- a/lib/utils/embargoedAssets.js
+++ b/lib/utils/embargoedAssets.js
@@ -18,9 +18,9 @@ function createAssetKey (host, accessToken, spaceId, environmentId, expiresAtMs)
 }
 
 export const shouldCreateNewCacheItem = (cacheItem, currentExpiresAtMs) =>
-  !cacheItem || currentExpiresAtMs - cacheItem.expiresAtMs < SIX_HOURS_IN_MS
+  !cacheItem || currentExpiresAtMs - cacheItem.expiresAtMs > SIX_HOURS_IN_MS
 
-async function createCachedAssetKey(host, accessToken, spaceId, environmentId, minExpiresAtMs) {
+async function createCachedAssetKey (host, accessToken, spaceId, environmentId, minExpiresAtMs) {
   const cacheKey = `${host}:${spaceId}:${environmentId}`
   let cacheItem = assetKeyCache.get(cacheKey)
 
@@ -36,7 +36,7 @@ async function createCachedAssetKey(host, accessToken, spaceId, environmentId, m
 
       const resolvedAssetKeyPromise = await assetKeyPromise
       const result = await resolvedAssetKeyPromise.json()
-      cacheItem = { expiresAtMs, result: result }
+      cacheItem = { expiresAtMs, result }
       assetKeyCache.set(cacheKey, cacheItem)
     } catch (err) {
       // If we encounter an error, make sure to clear the cache item if this is the most recent fetch.

--- a/test/unit/tasks/download-assets.test.js
+++ b/test/unit/tasks/download-assets.test.js
@@ -45,7 +45,7 @@ nock(`https://${API_HOST}`)
   .post(`/spaces/${SPACE_ID}/environments/${ENVIRONMENT_ID}/asset_keys`, {
     expiresAt: /.+/i
   })
-  .times(2)
+  .times(1)
   .reply(200, { policy: POLICY, secret: SECRET })
 
 function getAssets ({ existing = 0, nonExisting = 0, missingUrl = 0, embargoed = 0 } = {}) {

--- a/test/unit/utils/embargoedAssets.test.js
+++ b/test/unit/utils/embargoedAssets.test.js
@@ -1,0 +1,7 @@
+import { shouldCreateNewCacheItem } from '../../../lib/utils/embargoedAssets'
+const SIX_HOURS_IN_MS = 6 * 60 * 60 * 1000
+
+test('only returns true for expiry time difference less than 6 hours', () => {
+  expect(shouldCreateNewCacheItem({ expiresAtMs: 1 }, SIX_HOURS_IN_MS - 2)).toBe(true)
+  expect(shouldCreateNewCacheItem({ expiresAtMs: 1 }, SIX_HOURS_IN_MS + 2)).toBe(false)
+})

--- a/test/unit/utils/embargoedAssets.test.js
+++ b/test/unit/utils/embargoedAssets.test.js
@@ -1,7 +1,7 @@
 import { shouldCreateNewCacheItem } from '../../../lib/utils/embargoedAssets'
 const SIX_HOURS_IN_MS = 6 * 60 * 60 * 1000
 
-test('only returns true for expiry time difference less than 6 hours', () => {
-  expect(shouldCreateNewCacheItem({ expiresAtMs: 1 }, SIX_HOURS_IN_MS - 2)).toBe(true)
-  expect(shouldCreateNewCacheItem({ expiresAtMs: 1 }, SIX_HOURS_IN_MS + 2)).toBe(false)
+test('only returns true for expiry time difference greater than 6 hours', () => {
+  expect(shouldCreateNewCacheItem({ expiresAtMs: 1 }, SIX_HOURS_IN_MS - 2)).toBe(false)
+  expect(shouldCreateNewCacheItem({ expiresAtMs: 1 }, SIX_HOURS_IN_MS + 2)).toBe(true)
 })


### PR DESCRIPTION
Fixes a bug, as the current implementation would never cache at all (as `cacheItem.expiresAtMs < minExpiresAtMs` is always true). 

With this change, we will only create new cacheItems if the time difference between the last cachedItem expiry time and the current key expiry time is greater than 6 hours.

This is where download support for embargoed assets and the caching logic was introduced: https://github.com/contentful/contentful-export/pull/680
