### PR TITLE
Update example-config.json

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -9,24 +9,22 @@
   "includeDrafts": false,
   "includeArchived": false,
   "skipContentModel": false,
-  "skipEditorInterfaces": false,
   "skipContent": false,
   "skipRoles": false,
+  "skipTags": false,
   "skipWebhooks": false,
+  "stripTags": false,
   "contentOnly": false,
-  "queryEntries": [
-    "content_type=<content_type_id>",
-    "sys.id=<entry_id>"
-  ],
-  "queryAssets": [
-    "fields.title=Example"
-  ],
+  "queryEntries": ["content_type=<content_type_id>", "sys.id=<entry_id>"],
+  "queryAssets": ["fields.title=Example"],
   "downloadAssets": false,
   "host": "api.contentful.com",
   "proxy": "https://user:password@host:port",
   "rawProxy": false,
   "maxAllowedLimit": 1000,
-  "limit": 25000,
   "errorLogFile": "/path/to/error.log",
-  "useVerboseRenderer": false
+  "useVerboseRenderer": false,
+  "timeout": 20000,
+  "retryLimit": 10,
+  "header": "additional-http-header"
 }


### PR DESCRIPTION
The CLI no longer supports `skipEditorInterfaces, limit` and now supports `header, timeout, retryLimit, skipTags, stripTags`. Update to make the example config more accurate!