### PR TITLE
Remove skipEditorInterfaces and limit that are no longer supported

### DIFF
--- a/example-config.json
+++ b/example-config.json
@@ -9,7 +9,6 @@
   "includeDrafts": false,
   "includeArchived": false,
   "skipContentModel": false,
-  "skipEditorInterfaces": false,
   "skipContent": false,
   "skipRoles": false,
   "skipWebhooks": false,
@@ -26,7 +25,6 @@
   "proxy": "https://user:password@host:port",
   "rawProxy": false,
   "maxAllowedLimit": 1000,
-  "limit": 25000,
   "errorLogFile": "/path/to/error.log",
   "useVerboseRenderer": false
 }


### PR DESCRIPTION
Does less than PR #1282 and simply removes unsupported params of `skipEditorInterfaces, limit` so people like me stop running into this issue. 👍 