### PR TITLE
chore: updates to allow usage of newer cda client []

### DIFF
--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -88,12 +88,11 @@ export default function getFullSourceSpace ({
     {
       title: 'Fetching content entries data',
       task: wrapTask((ctx) => {
-        const source = cdaClient || ctx.environment
+        const source = cdaClient?.withAllLocales || ctx.environment
         if (cdaClient) {
           // let's not fetch children when using Content Delivery API
           queryEntries = queryEntries || {}
           queryEntries.include = 0
-          queryEntries.locale = '*'
         }
         return pagedGet({ source, method: 'getEntries', query: queryEntries })
           .then(extractItems)
@@ -109,9 +108,8 @@ export default function getFullSourceSpace ({
     {
       title: 'Fetching assets data',
       task: wrapTask((ctx) => {
-        const source = cdaClient || ctx.environment
+        const source = cdaClient?.withAllLocales || ctx.environment
         queryAssets = queryAssets || {}
-        queryAssets.locale = '*'
         return pagedGet({ source, method: 'getAssets', query: queryAssets })
           .then(extractItems)
           .then((items) => filterDrafts(items, includeDrafts, cdaClient))

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -191,7 +191,7 @@ function pagedGet ({ source, method, skip = 0, aggregatedResponse = null, query 
   }
   const fullQuery = Object.assign({},
     {
-      skip: skip,
+      skip,
       order: 'sys.createdAt,sys.id'
     },
     query,

--- a/lib/tasks/init-client.js
+++ b/lib/tasks/init-client.js
@@ -19,10 +19,9 @@ export default function initClient (opts, useCda = false) {
     const cdaConfig = {
       space: config.spaceId,
       accessToken: config.deliveryToken,
-      environment: config.environmentId,
-      resolveLinks: false
+      environment: config.environmentId
     }
-    return createCdaClient(cdaConfig)
+    return createCdaClient(cdaConfig).withoutLinkResolution
   }
   return createCmaClient(config)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "bfj": "^8.0.0",
         "bluebird": "^3.3.3",
         "cli-table3": "^0.6.0",
-        "contentful": "^9.0.0",
+        "contentful": "^10.6.9",
         "contentful-batch-libs": "^9.4.1",
         "contentful-management": "^11.0.1",
         "date-fns": "^2.28.0",
@@ -5046,12 +5046,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -5508,6 +5509,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
       "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.1",
@@ -5983,17 +5985,16 @@
       }
     },
     "node_modules/contentful": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/contentful/-/contentful-9.3.5.tgz",
-      "integrity": "sha512-QVXHwD9nxREBpcemC6Po2LUYStmBBHPyVbN3SKzkR+WmIZhflF6x+TDmmz2jcCg/RSN+INDZbhe8FQ1S/zTE8w==",
-      "hasInstallScript": true,
+      "version": "10.6.9",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.6.9.tgz",
+      "integrity": "sha512-OanVTe4i0l5N6WkSDEwx9Lt/XVoeevNDODn0XHEr56ShGs+a3/nJxaNUjNr4WmX9BklgARvsiOBsl/XTz5OVbQ==",
       "dependencies": {
         "@contentful/rich-text-types": "^16.0.2",
-        "axios": "^0.27.0",
-        "contentful-resolve-response": "^1.3.12",
-        "contentful-sdk-core": "^7.0.5",
-        "fast-copy": "^2.1.7",
-        "json-stringify-safe": "^5.0.1"
+        "axios": "^1.6.0",
+        "contentful-resolve-response": "^1.8.1",
+        "contentful-sdk-core": "^8.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "type-fest": "^4.0.0"
       },
       "engines": {
         "node": ">=12"
@@ -6031,44 +6032,15 @@
         "node": ">=18"
       }
     },
-    "node_modules/contentful-management/node_modules/axios": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
-      "dependencies": {
-        "follow-redirects": "^1.15.0",
-        "form-data": "^4.0.0",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
-    "node_modules/contentful-management/node_modules/contentful-sdk-core": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.1.0.tgz",
-      "integrity": "sha512-ZXTtrkrx4OlRcVY0WLihrskF+BSuHe7QZuWA8DNEeTlHmkPXAVch9Og5TJDoyGeqNrArR3Ovd7yfaG+1QYo+ag==",
-      "dependencies": {
-        "fast-copy": "^2.1.7",
-        "lodash.isplainobject": "^4.0.6",
-        "lodash.isstring": "^4.0.1",
-        "p-throttle": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/contentful-management/node_modules/contentful-sdk-core/node_modules/fast-copy": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
-      "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
-    },
     "node_modules/contentful-management/node_modules/fast-copy": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.0.tgz",
       "integrity": "sha512-4HzS+9pQ5Yxtv13Lhs1Z1unMXamBdn5nA4bEi1abYpDNSpSp7ODYQ1KPMF6nTatfEzgH6/zPvXKU1zvHiUjWlA=="
     },
     "node_modules/contentful-resolve-response": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.3.12.tgz",
-      "integrity": "sha512-fe2dsACyV3jzRjHcoeAa4bBt06YwkdsY+kdQwFCcdETyBQIxifuyGamIF4NmKcDqvZ9Yhw7ujjPCadzHb9jmKw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.8.1.tgz",
+      "integrity": "sha512-VXGK2c8dBIGcRCknqudKmkDr2PzsUYfjLN6hhx71T09UzoXOdA/c0kfDhsf/BBCBWPWcLaUgaJEFU0lCo45TSg==",
       "dependencies": {
         "fast-copy": "^2.1.7"
       },
@@ -6077,15 +6049,14 @@
       }
     },
     "node_modules/contentful-sdk-core": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.5.tgz",
-      "integrity": "sha512-GG+DvFRwaoTeco072WjN+uyfpHs8Gilxl3ryJcXo3mlxeN/A/inbAqhX+RrKB5HNOVREdNWeMBAg0D7hLvlBXQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.1.1.tgz",
+      "integrity": "sha512-0oWZmU4V9AgFVwljJLQc1sQJzxSodnLQk9TCmUTFw12rjiloPKYLRo4iz6KJD1enyVmZsz+Ckb0wADUVvFKg6A==",
       "dependencies": {
         "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
-        "p-throttle": "^4.1.1",
-        "qs": "^6.9.4"
+        "p-throttle": "^4.1.1"
       },
       "engines": {
         "node": ">=12"
@@ -6486,6 +6457,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
       "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.1",
         "gopd": "^1.0.1",
@@ -8185,6 +8157,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -8228,6 +8201,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
       "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
@@ -8440,6 +8414,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -8520,6 +8495,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
       "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.2"
       },
@@ -8531,6 +8507,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8542,6 +8519,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8568,6 +8546,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -15940,6 +15919,7 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -16808,20 +16788,6 @@
           "url": "https://opencollective.com/fast-check"
         }
       ]
-    },
-    "node_modules/qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
-      "dependencies": {
-        "side-channel": "^1.0.4"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -17882,6 +17848,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
       "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "dev": true,
       "dependencies": {
         "define-data-property": "^1.1.1",
         "get-intrinsic": "^1.2.1",
@@ -17937,6 +17904,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -22686,12 +22654,13 @@
       "dev": true
     },
     "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.1.tgz",
+      "integrity": "sha512-vfBmhDpKafglh0EldBEbVuoe7DyAavGSLWhuSm5ZSEKQnHhBf0xAAwybbNH1IkrJNGnS/VG4I5yxig1pCEXE4g==",
       "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "babel-jest": {
@@ -23030,6 +22999,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
       "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.1",
@@ -23380,16 +23350,16 @@
       }
     },
     "contentful": {
-      "version": "9.3.5",
-      "resolved": "https://registry.npmjs.org/contentful/-/contentful-9.3.5.tgz",
-      "integrity": "sha512-QVXHwD9nxREBpcemC6Po2LUYStmBBHPyVbN3SKzkR+WmIZhflF6x+TDmmz2jcCg/RSN+INDZbhe8FQ1S/zTE8w==",
+      "version": "10.6.9",
+      "resolved": "https://registry.npmjs.org/contentful/-/contentful-10.6.9.tgz",
+      "integrity": "sha512-OanVTe4i0l5N6WkSDEwx9Lt/XVoeevNDODn0XHEr56ShGs+a3/nJxaNUjNr4WmX9BklgARvsiOBsl/XTz5OVbQ==",
       "requires": {
         "@contentful/rich-text-types": "^16.0.2",
-        "axios": "^0.27.0",
-        "contentful-resolve-response": "^1.3.12",
-        "contentful-sdk-core": "^7.0.5",
-        "fast-copy": "^2.1.7",
-        "json-stringify-safe": "^5.0.1"
+        "axios": "^1.6.0",
+        "contentful-resolve-response": "^1.8.1",
+        "contentful-sdk-core": "^8.1.0",
+        "json-stringify-safe": "^5.0.1",
+        "type-fest": "^4.0.0"
       }
     },
     "contentful-batch-libs": {
@@ -23418,34 +23388,6 @@
         "type-fest": "^4.0.0"
       },
       "dependencies": {
-        "axios": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
-          "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
-          "requires": {
-            "follow-redirects": "^1.15.0",
-            "form-data": "^4.0.0",
-            "proxy-from-env": "^1.1.0"
-          }
-        },
-        "contentful-sdk-core": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.1.0.tgz",
-          "integrity": "sha512-ZXTtrkrx4OlRcVY0WLihrskF+BSuHe7QZuWA8DNEeTlHmkPXAVch9Og5TJDoyGeqNrArR3Ovd7yfaG+1QYo+ag==",
-          "requires": {
-            "fast-copy": "^2.1.7",
-            "lodash.isplainobject": "^4.0.6",
-            "lodash.isstring": "^4.0.1",
-            "p-throttle": "^4.1.1"
-          },
-          "dependencies": {
-            "fast-copy": {
-              "version": "2.1.7",
-              "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-2.1.7.tgz",
-              "integrity": "sha512-ozrGwyuCTAy7YgFCua8rmqmytECYk/JYAMXcswOcm0qvGoE3tPb7ivBeIHTOK2DiapBhDZgacIhzhQIKU5TCfA=="
-            }
-          }
-        },
         "fast-copy": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/fast-copy/-/fast-copy-3.0.0.tgz",
@@ -23454,23 +23396,22 @@
       }
     },
     "contentful-resolve-response": {
-      "version": "1.3.12",
-      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.3.12.tgz",
-      "integrity": "sha512-fe2dsACyV3jzRjHcoeAa4bBt06YwkdsY+kdQwFCcdETyBQIxifuyGamIF4NmKcDqvZ9Yhw7ujjPCadzHb9jmKw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/contentful-resolve-response/-/contentful-resolve-response-1.8.1.tgz",
+      "integrity": "sha512-VXGK2c8dBIGcRCknqudKmkDr2PzsUYfjLN6hhx71T09UzoXOdA/c0kfDhsf/BBCBWPWcLaUgaJEFU0lCo45TSg==",
       "requires": {
         "fast-copy": "^2.1.7"
       }
     },
     "contentful-sdk-core": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-7.0.5.tgz",
-      "integrity": "sha512-GG+DvFRwaoTeco072WjN+uyfpHs8Gilxl3ryJcXo3mlxeN/A/inbAqhX+RrKB5HNOVREdNWeMBAg0D7hLvlBXQ==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/contentful-sdk-core/-/contentful-sdk-core-8.1.1.tgz",
+      "integrity": "sha512-0oWZmU4V9AgFVwljJLQc1sQJzxSodnLQk9TCmUTFw12rjiloPKYLRo4iz6KJD1enyVmZsz+Ckb0wADUVvFKg6A==",
       "requires": {
         "fast-copy": "^2.1.7",
         "lodash.isplainobject": "^4.0.6",
         "lodash.isstring": "^4.0.1",
-        "p-throttle": "^4.1.1",
-        "qs": "^6.9.4"
+        "p-throttle": "^4.1.1"
       }
     },
     "conventional-changelog-angular": {
@@ -23772,6 +23713,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
       "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "dev": true,
       "requires": {
         "get-intrinsic": "^1.2.1",
         "gopd": "^1.0.1",
@@ -24954,7 +24896,8 @@
     "function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true
     },
     "function.prototype.name": {
       "version": "1.1.6",
@@ -24983,6 +24926,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
       "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
@@ -25145,6 +25089,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "dev": true,
       "requires": {
         "get-intrinsic": "^1.1.3"
       }
@@ -25204,6 +25149,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
       "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "dev": true,
       "requires": {
         "get-intrinsic": "^1.2.2"
       }
@@ -25211,12 +25157,14 @@
     "has-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg=="
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A=="
+      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "dev": true
     },
     "has-tostringtag": {
       "version": "1.0.0",
@@ -25231,6 +25179,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.2"
       }
@@ -30399,7 +30348,8 @@
     "object-inspect": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ=="
+      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "dev": true
     },
     "object-keys": {
       "version": "1.1.1",
@@ -31011,14 +30961,6 @@
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.3.tgz",
       "integrity": "sha512-KddyFewCsO0j3+np81IQ+SweXLDnDQTs5s67BOnrYmYe/yNmUhttQyGsYzy8yUnoljGAQ9sl38YB4vH8ur7Y+w==",
       "dev": true
-    },
-    "qs": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
-      "requires": {
-        "side-channel": "^1.0.4"
-      }
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -31743,6 +31685,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
       "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "dev": true,
       "requires": {
         "define-data-property": "^1.1.1",
         "get-intrinsic": "^1.2.1",
@@ -31786,6 +31729,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "dev": true,
       "requires": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "bfj": "^8.0.0",
     "bluebird": "^3.3.3",
     "cli-table3": "^0.6.0",
-    "contentful": "^9.0.0",
+    "contentful": "^10.6.9",
     "contentful-batch-libs": "^9.4.1",
     "contentful-management": "^11.0.1",
     "date-fns": "^2.28.0",

--- a/test/unit/tasks/init-client.test.js
+++ b/test/unit/tasks/init-client.test.js
@@ -98,7 +98,6 @@ test('does create both clients when deliveryToken is set', () => {
   expect(contentful.createClient.mock.calls[0][0]).toMatchObject({
     space: opts.spaceId,
     accessToken: opts.deliveryToken,
-    resolveLinks: false
   })
   expect(contentfulManagement.createClient.mock.calls).toHaveLength(1)
   expect(contentful.createClient.mock.calls).toHaveLength(1)


### PR DESCRIPTION
These tweaks allow us to upgrade contentful.js

I came to these conclusions via these error messages:

```
[Error: ValidationError: Invalid "resolveLinks" provided, The use of the 'resolveLinks' parameter is no longer supported. By default, links are resolved. If you do not want to resolve links, use client.withoutLinkResolution.]

[Error: ValidationError: Invalid "locale" provided, The use of locale='*' is no longer supported.To fetch an entry in all existing locales, use client.withAllLocales instead of the locale='*' parameter.]
```