### PR TITLE
fix: 'skipTags' missing in Options

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -26,6 +26,7 @@ export interface Options {
   skipEditorInterfaces?: boolean;
   skipRoles?: boolean;
   skipWebhooks?: boolean;
+  skipTags?: boolean;
   useVerboseRenderer?: boolean;
 }
 


### PR DESCRIPTION
skipTags is missing in the types...