### PR TITLE
fix: allow host-delivery config to be passed to export command [EXT-5986]

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ Download actual asset files
 #### `host` [string] [default: 'api.contentful.com']
 The Management API host
 
+#### `hostDelivery` [string] [default: 'cdn.contentful.com']
+The Delivery API host
+
 #### `proxy` [string]
 Proxy configuration in HTTP auth format: `host:port` or `user:password@host:port`
 

--- a/lib/tasks/init-client.js
+++ b/lib/tasks/init-client.js
@@ -19,7 +19,8 @@ export default function initClient (opts, useCda = false) {
     const cdaConfig = {
       space: config.spaceId,
       accessToken: config.deliveryToken,
-      environment: config.environmentId
+      environment: config.environmentId,
+      host: config.hostDelivery,
     }
     return createCdaClient(cdaConfig).withoutLinkResolution
   }

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -86,6 +86,11 @@ export default yargs
     type: 'string',
     default: 'api.contentful.com'
   })
+  .option('host-delivery', {
+    describe: 'Delivery API host',
+    type: 'string',
+    default: 'cdn.contentful.com'
+  })
   .option('proxy', {
     describe: 'Proxy configuration in HTTP auth format: [http|https]://host:port or [http|https]://user:password@host:port',
     type: 'string'


### PR DESCRIPTION
Allows the hostDelivery option to be used to point the export at cdn.eu.contentful.com when a deliveryToken is used to export entries from the CDA