### PR TITLE
feat: support all sdk config options when using CDA

### DIFF
--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -26,6 +26,7 @@ export default function parseOptions (params) {
   }
 
   const configFile = params.config
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
     ? require(resolve(process.cwd(), params.config))
     : {}
 

--- a/lib/tasks/init-client.js
+++ b/lib/tasks/init-client.js
@@ -17,10 +17,11 @@ export default function initClient (opts, useCda = false) {
   }
   if (useCda) {
     const cdaConfig = {
+      ...config,
       space: config.spaceId,
       accessToken: config.deliveryToken,
       environment: config.environmentId,
-      host: config.hostDelivery,
+      host: config.hostDelivery
     }
     return createCdaClient(cdaConfig).withoutLinkResolution
   }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "build:watch": "babel lib --out-dir dist --watch",
     "clean": "rimraf dist && rimraf coverage",
     "lint": "eslint lib bin/* types.d.ts",
+    "lint:fix": "npm run lint -- --fix",
     "pretest": "npm run lint && npm run build && rimraf ./test/integration/tmp",
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "jest --testPathPattern=test/unit --coverage",

--- a/test/unit/tasks/init-client.test.js
+++ b/test/unit/tasks/init-client.test.js
@@ -78,7 +78,8 @@ test('does create both clients when deliveryToken is set', () => {
     proxy: 'proxy',
     accessToken: 'accessToken',
     spaceId: 'spaceId',
-    deliveryToken: 'deliveryToken'
+    deliveryToken: 'deliveryToken',
+    hostDelivery: 'hostDelivery'
   }
 
   initClient(opts, true)
@@ -98,6 +99,15 @@ test('does create both clients when deliveryToken is set', () => {
   expect(contentful.createClient.mock.calls[0][0]).toMatchObject({
     space: opts.spaceId,
     accessToken: opts.deliveryToken,
+    host: opts.hostDelivery,
+    port: opts.port,
+    headers: opts.headers,
+    insecure: opts.insecure,
+    proxy: opts.proxy,
+    httpAgent: opts.httpAgent,
+    httpsAgent: opts.httpsAgent,
+    application: opts.application,
+    integration: opts.integration
   })
   expect(contentfulManagement.createClient.mock.calls).toHaveLength(1)
   expect(contentful.createClient.mock.calls).toHaveLength(1)


### PR DESCRIPTION
Pass through all SDK config options (namely `httpAgent` and `httpsAgent`) when using the CDA to export

fixes: https://github.com/contentful/contentful-export/issues/1821

