### PR TITLE
fix: asset name in logs [ZEND-5790]

### DIFF
--- a/lib/tasks/download-assets.js
+++ b/lib/tasks/download-assets.js
@@ -61,8 +61,9 @@ export default function downloadAssets (options) {
     })
 
     return Promise.map(ctx.data.assets, (asset) => {
+      const entityName = getEntityName(asset)
       if (!asset.fields.file) {
-        task.output = `${figures.warning} asset ${getEntityName(asset)} has no file(s)`
+        task.output = `${figures.warning} asset ${entityName} has no file(s)`
         warningCount++
         return
       }
@@ -70,7 +71,7 @@ export default function downloadAssets (options) {
       return Promise.mapSeries(locales, (locale) => {
         const url = asset.fields.file[locale].url
         if (!url) {
-          task.output = `${figures.cross} asset '${getEntityName(asset)}' doesn't contain an url in path asset.fields.file[${locale}].url`
+          task.output = `${figures.cross} asset '${entityName}' doesn't contain an url in path asset.fields.file[${locale}].url`
           errorCount++
 
           return Promise.resolve()
@@ -89,7 +90,7 @@ export default function downloadAssets (options) {
         return startingPromise
           .then(downloadAsset)
           .then((downLoadedFile) => {
-            task.output = `${figures.tick} downloaded ${getEntityName(downLoadedFile)} (${url})`
+            task.output = `${figures.tick} downloaded ${entityName} (${url})`
             successCount++
           })
           .catch((error) => {


### PR DESCRIPTION
This PR fixes an issue when using the `useVerboseRenderer` option, the asset name is showing up as "unknown"

before fix:
```
[14:11:13] Download assets [started]
[14:11:13] → ✔ downloaded unknown (//images.ctfassets.net/.../image.png)
```

after fix:
```
[14:34:44] Download assets [started]
[14:34:44] → ✔ downloaded image.png (//images.ctfassets.net/<space_id>/<etc>/.../image.png)
```