### PR TITLE
fix: asset download using axios [ZEND-5790]

### DIFF
--- a/lib/tasks/download-assets.js
+++ b/lib/tasks/download-assets.js
@@ -32,7 +32,10 @@ async function downloadAsset ({ url, directory, httpClient }) {
 
   try {
     // download asset
-    const assetRequest = await httpClient.get(url, { responseType: 'blob' })
+    const assetRequest = await httpClient.get(url, {
+      responseType: "stream",
+      transformResponse: [(data) => data],
+    })
 
     // Wait for stream to be consumed before returning local file
     await streamPipeline(assetRequest.data, file)
@@ -89,7 +92,7 @@ export default function downloadAssets (options) {
 
         return startingPromise
           .then(downloadAsset)
-          .then((downLoadedFile) => {
+          .then((_downLoadedFile) => {
             task.output = `${figures.tick} downloaded ${entityName} (${url})`
             successCount++
           })


### PR DESCRIPTION
Need a small adjustment to ensure assets downloaded via the axios client are saved correctly - in particular, we adjust the response type to be stream instead of blob and ensure that no transformations are made to the data stream