### PR TITLE
feat: ExO export support — flag, cursor pagination, entity tasks [AIS-117, AIS-119]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
 
   release:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/feat/exo')
     needs: [build, check]
     permissions:
       contents: write

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,7 @@ export default function runContentfulExport (params) {
             skipRoles: options.skipRoles,
             skipTags: options.skipTags,
             stripTags: options.stripTags,
+            includeExperienceOrchestration: options.includeExperienceOrchestration,
             listrOptions,
             queryEntries: options.queryEntries,
             queryAssets: options.queryAssets

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -20,6 +20,7 @@ export default function parseOptions (params) {
     skipTags: false,
     stripTags: false,
     maxAllowedLimit: 1000,
+    includeExperienceOrchestration: false,
     saveFile: true,
     useVerboseRenderer: false,
     rawProxy: false

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -25,6 +25,7 @@ export default function getFullSourceSpace ({
   includeDrafts,
   includeArchived,
   maxAllowedLimit,
+  includeExperienceOrchestration,
   listrOptions,
   queryEntries,
   queryAssets
@@ -153,6 +154,78 @@ export default function getFullSourceSpace ({
           })
       }),
       skip: () => skipRoles || (environmentId !== 'master' && 'Roles can only be exported from master environment')
+    },
+    {
+      title: 'Fetching Design Tokens data',
+      task: wrapTask(async (ctx) => {
+        try {
+          ctx.data.designTokens = await cursorPagedGet({ client, spaceId, environmentId, method: 'designToken.getMany' })
+        } catch (err) {
+          logEmitter.emit('warning', `Skipping Design Tokens export: ${err.message}`)
+          ctx.data.designTokens = []
+        }
+      }),
+      skip: () => !includeExperienceOrchestration
+    },
+    {
+      title: 'Fetching Component Types data',
+      task: wrapTask(async (ctx) => {
+        try {
+          ctx.data.componentTypes = await cursorPagedGet({ client, spaceId, environmentId, method: 'componentType.getMany' })
+        } catch (err) {
+          logEmitter.emit('warning', `Skipping Component Types export: ${err.message}`)
+          ctx.data.componentTypes = []
+        }
+      }),
+      skip: () => !includeExperienceOrchestration
+    },
+    {
+      title: 'Fetching Templates data',
+      task: wrapTask(async (ctx) => {
+        try {
+          ctx.data.templates = await cursorPagedGet({ client, spaceId, environmentId, method: 'template.getMany' })
+        } catch (err) {
+          logEmitter.emit('warning', `Skipping Templates export: ${err.message}`)
+          ctx.data.templates = []
+        }
+      }),
+      skip: () => !includeExperienceOrchestration
+    },
+    {
+      title: 'Fetching Data Assemblies data',
+      task: wrapTask(async (ctx) => {
+        try {
+          ctx.data.dataAssemblies = await cursorPagedGet({ client, spaceId, environmentId, method: 'dataAssembly.getMany' })
+        } catch (err) {
+          logEmitter.emit('warning', `Skipping Data Assemblies export: ${err.message}`)
+          ctx.data.dataAssemblies = []
+        }
+      }),
+      skip: () => !includeExperienceOrchestration
+    },
+    {
+      title: 'Fetching Fragments data',
+      task: wrapTask(async (ctx) => {
+        try {
+          ctx.data.fragments = await cursorPagedGet({ client, spaceId, environmentId, method: 'fragment.getMany' })
+        } catch (err) {
+          logEmitter.emit('warning', `Skipping Fragments export: ${err.message}`)
+          ctx.data.fragments = []
+        }
+      }),
+      skip: () => !includeExperienceOrchestration
+    },
+    {
+      title: 'Fetching Experiences data',
+      task: wrapTask(async (ctx) => {
+        try {
+          ctx.data.experiences = await cursorPagedGet({ client, spaceId, environmentId, method: 'experience.getMany' })
+        } catch (err) {
+          logEmitter.emit('warning', `Skipping Experiences export: ${err.message}`)
+          ctx.data.experiences = []
+        }
+      }),
+      skip: () => !includeExperienceOrchestration
     }
   ], listrOptions)
 }
@@ -173,6 +246,29 @@ function getEditorInterfaces (contentTypes) {
   }, {
     concurrency: 6
   })
+}
+
+/**
+ * Gets all ExO entities using cursor-based pagination (pageNext/pagePrev tokens).
+ * ExO list endpoints do not support skip-based pagination or the order param.
+ */
+async function cursorPagedGet ({ client, spaceId, environmentId, method }) {
+  const [entity, operation] = method.split('.')
+  const allItems = []
+  let pageNext = null
+
+  do {
+    const query = { spaceId, environmentId, limit: pageLimit }
+    if (pageNext) {
+      query.pageNext = pageNext
+    }
+    const response = await client[entity][operation](query)
+    allItems.push(...response.items)
+    logEmitter.emit('info', `Fetched ${allItems.length} ${entity} items`)
+    pageNext = response.pages?.next ?? null
+  } while (pageNext)
+
+  return allItems
 }
 
 /**

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -126,6 +126,11 @@ export default yargs
     type: 'boolean',
     default: false
   })
+  .option('include-experience-orchestration', {
+    describe: 'Include Experience Orchestration entities (Component Types, Templates, Data Assemblies, Fragments, Experiences, Design Tokens). Requires exo_m1 entitlement on the source space.',
+    type: 'boolean',
+    default: false
+  })
   .option('header', {
     alias: 'H',
     type: 'string',

--- a/package.json
+++ b/package.json
@@ -109,6 +109,11 @@
         "name": "beta",
         "channel": "beta",
         "prerelease": true
+      },
+      {
+        "name": "feat/exo",
+        "channel": "exo",
+        "prerelease": "exo"
       }
     ],
     "plugins": [

--- a/types.d.ts
+++ b/types.d.ts
@@ -28,9 +28,10 @@ export interface Options {
   skipWebhooks?: boolean;
   skipTags?: boolean;
   useVerboseRenderer?: boolean;
+  includeExperienceOrchestration?: boolean;
 }
 
-type ContentfulExportField = 'contentTypes' | 'entries' | 'assets' | 'locales' | 'tags' | 'webhooks' | 'roles' | 'editorInterfaces';
+type ContentfulExportField = 'contentTypes' | 'entries' | 'assets' | 'locales' | 'tags' | 'webhooks' | 'roles' | 'editorInterfaces' | 'designTokens' | 'componentTypes' | 'templates' | 'dataAssemblies' | 'fragments' | 'experiences';
 
 declare const runContentfulExport: (params: Options) => Promise<Record<ContentfulExportField, unknown[]>>
 export default runContentfulExport


### PR DESCRIPTION
## Summary

Adds the foundation for exporting Experience Orchestration (ExO) entities from a Contentful space.

- Introduces `includeExperienceOrchestration` opt-in flag (default: `false`) — spaces without the `exo_m1` entitlement are unaffected
- Adds `cursorPagedGet()` helper for ExO list endpoints, which use cursor-based (`pageNext`/`pagePrev`) pagination instead of skip-based pagination
- Wires Listr tasks for all 6 ExO entity types: `designTokens`, `componentTypes`, `templates`, `dataAssemblies`, `fragments`, `experiences`
- Each task gracefully degrades (warning + empty array) on 404/403 — no breakage on non-entitled spaces

## What's not yet working

The ExO fetch tasks will throw until `contentful-management` ships the `feat/exo` SDK branch (full CRUD for ComponentType, Template, Fragment, Experience, DataAssembly). That's caught by the per-task try/catch. Tracked in [AIS-135](https://contentful.atlassian.net/browse/AIS-135).

## Test plan

- [ ] `npm run build` passes (TypeScript check + Babel compile)
- [ ] `npm run test:unit` — all 49 existing tests pass, no regressions
- [ ] Manual: export a space without `exo_m1` — no ExO keys appear in output, no errors
- [ ] Manual: export with `--include-experience-orchestration` against an entitled space once SDK is released — all 6 ExO arrays present in output JSON
- [ ] Integration tests to be added in [AIS-133](https://contentful.atlassian.net/browse/AIS-133)

## Related tickets

- [AIS-96](https://contentful.atlassian.net/browse/AIS-96) — Epic: ExO for Import/Export
- [AIS-117](https://contentful.atlassian.net/browse/AIS-117) — Cursor-based pagination
- [AIS-119](https://contentful.atlassian.net/browse/AIS-119) — `includeExperienceOrchestration` flag
- [AIS-120](https://contentful.atlassian.net/browse/AIS-120) – [AIS-125](https://contentful.atlassian.net/browse/AIS-125) — Individual entity fetch tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[AIS-135]: https://contentful.atlassian.net/browse/AIS-135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIS-133]: https://contentful.atlassian.net/browse/AIS-133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ