### PR TITLE
chore: add exo semantic-release channel [AIS-117]

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
 
   release:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/exo')
     needs: [build, check]
     permissions:
       contents: write

--- a/package.json
+++ b/package.json
@@ -109,6 +109,11 @@
         "name": "beta",
         "channel": "beta",
         "prerelease": true
+      },
+      {
+        "name": "exo",
+        "channel": "exo",
+        "prerelease": "exo"
       }
     ],
     "plugins": [


### PR DESCRIPTION
## Summary
Create a exo build example: `contentful-export@1.x.x-exo.1`

- Adds `exo` branch to `release.branches` in `package.json` with `channel: exo` and `prerelease: exo` — releases from this branch will be versioned as `x.y.z-exo.N`
- Updates CI release gate in `.github/workflows/main.yaml` to allow semantic-release to run on pushes to `refs/heads/exo`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)