### PR TITLE
feat: add ExO export support [AIS-117, AIS-119]

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ import {
 
 import downloadAssets from './tasks/download-assets'
 import getSpaceData from './tasks/get-space-data'
-import initClient from './tasks/init-client'
+import initClient, { initPlainClient } from './tasks/init-client'
 
 import parseOptions from './parseOptions'
 
@@ -60,6 +60,7 @@ export default function runContentfulExport (params) {
           try {
             // CMA client
             ctx.client = initClient(options)
+            ctx.plainClient = initPlainClient(options)
             if (options.deliveryToken && !options.includeDrafts) {
               // CDA client for fetching only public entries
               ctx.cdaClient = initClient(options, true)
@@ -75,6 +76,7 @@ export default function runContentfulExport (params) {
         task: (ctx) => {
           return getSpaceData({
             client: ctx.client,
+            plainClient: ctx.plainClient,
             cdaClient: ctx.cdaClient,
             spaceId: options.spaceId,
             environmentId: options.environmentId,

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,7 @@ export default function runContentfulExport (params) {
             skipRoles: options.skipRoles,
             skipTags: options.skipTags,
             stripTags: options.stripTags,
+            includeExperienceOrchestration: options.includeExperienceOrchestration,
             listrOptions,
             queryEntries: options.queryEntries,
             queryAssets: options.queryAssets

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -20,6 +20,7 @@ export default function parseOptions (params) {
     skipTags: false,
     stripTags: false,
     maxAllowedLimit: 1000,
+    includeExperienceOrchestration: false,
     saveFile: true,
     useVerboseRenderer: false,
     rawProxy: false

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -12,6 +12,7 @@ let pageLimit = MAX_ALLOWED_LIMIT
  */
 export default function getFullSourceSpace ({
   client,
+  plainClient,
   cdaClient,
   spaceId,
   environmentId = 'master',
@@ -159,7 +160,7 @@ export default function getFullSourceSpace ({
       title: 'Fetching Design Tokens data',
       task: wrapTask(async (ctx) => {
         try {
-          ctx.data.designTokens = await cursorPagedGet({ client, spaceId, environmentId, method: 'designToken.getMany' })
+          ctx.data.designTokens = await cursorPagedGet({ client: plainClient, spaceId, environmentId, method: 'designToken.getMany' })
         } catch (err) {
           logEmitter.emit('warning', `Skipping Design Tokens export: ${err.message}`)
           ctx.data.designTokens = []
@@ -171,7 +172,7 @@ export default function getFullSourceSpace ({
       title: 'Fetching Component Types data',
       task: wrapTask(async (ctx) => {
         try {
-          ctx.data.componentTypes = await cursorPagedGet({ client, spaceId, environmentId, method: 'componentType.getMany' })
+          ctx.data.componentTypes = await cursorPagedGet({ client: plainClient, spaceId, environmentId, method: 'componentType.getMany' })
         } catch (err) {
           logEmitter.emit('warning', `Skipping Component Types export: ${err.message}`)
           ctx.data.componentTypes = []
@@ -183,7 +184,7 @@ export default function getFullSourceSpace ({
       title: 'Fetching Templates data',
       task: wrapTask(async (ctx) => {
         try {
-          ctx.data.templates = await cursorPagedGet({ client, spaceId, environmentId, method: 'template.getMany' })
+          ctx.data.templates = await cursorPagedGet({ client: plainClient, spaceId, environmentId, method: 'template.getMany' })
         } catch (err) {
           logEmitter.emit('warning', `Skipping Templates export: ${err.message}`)
           ctx.data.templates = []
@@ -195,7 +196,7 @@ export default function getFullSourceSpace ({
       title: 'Fetching Data Assemblies data',
       task: wrapTask(async (ctx) => {
         try {
-          ctx.data.dataAssemblies = await cursorPagedGet({ client, spaceId, environmentId, method: 'dataAssembly.getMany' })
+          ctx.data.dataAssemblies = await cursorPagedGet({ client: plainClient, spaceId, environmentId, method: 'dataAssembly.getMany' })
         } catch (err) {
           logEmitter.emit('warning', `Skipping Data Assemblies export: ${err.message}`)
           ctx.data.dataAssemblies = []
@@ -207,7 +208,7 @@ export default function getFullSourceSpace ({
       title: 'Fetching Fragments data',
       task: wrapTask(async (ctx) => {
         try {
-          ctx.data.fragments = await cursorPagedGet({ client, spaceId, environmentId, method: 'fragment.getMany' })
+          ctx.data.fragments = await cursorPagedGet({ client: plainClient, spaceId, environmentId, method: 'fragment.getMany' })
         } catch (err) {
           logEmitter.emit('warning', `Skipping Fragments export: ${err.message}`)
           ctx.data.fragments = []
@@ -219,7 +220,7 @@ export default function getFullSourceSpace ({
       title: 'Fetching Experiences data',
       task: wrapTask(async (ctx) => {
         try {
-          ctx.data.experiences = await cursorPagedGet({ client, spaceId, environmentId, method: 'experience.getMany' })
+          ctx.data.experiences = await cursorPagedGet({ client: plainClient, spaceId, environmentId, method: 'experience.getMany' })
         } catch (err) {
           logEmitter.emit('warning', `Skipping Experiences export: ${err.message}`)
           ctx.data.experiences = []

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -25,6 +25,7 @@ export default function getFullSourceSpace ({
   includeDrafts,
   includeArchived,
   maxAllowedLimit,
+  includeExperienceOrchestration,
   listrOptions,
   queryEntries,
   queryAssets
@@ -153,6 +154,78 @@ export default function getFullSourceSpace ({
           })
       }),
       skip: () => skipRoles || (environmentId !== 'master' && 'Roles can only be exported from master environment')
+    },
+    {
+      title: 'Fetching Design Tokens data',
+      task: wrapTask(async (ctx) => {
+        try {
+          ctx.data.designTokens = await cursorPagedGet({ client, spaceId, environmentId, method: 'designToken.getMany' })
+        } catch (err) {
+          logEmitter.emit('warning', `Skipping Design Tokens export: ${err.message}`)
+          ctx.data.designTokens = []
+        }
+      }),
+      skip: () => !includeExperienceOrchestration
+    },
+    {
+      title: 'Fetching Component Types data',
+      task: wrapTask(async (ctx) => {
+        try {
+          ctx.data.componentTypes = await cursorPagedGet({ client, spaceId, environmentId, method: 'componentType.getMany' })
+        } catch (err) {
+          logEmitter.emit('warning', `Skipping Component Types export: ${err.message}`)
+          ctx.data.componentTypes = []
+        }
+      }),
+      skip: () => !includeExperienceOrchestration
+    },
+    {
+      title: 'Fetching Templates data',
+      task: wrapTask(async (ctx) => {
+        try {
+          ctx.data.templates = await cursorPagedGet({ client, spaceId, environmentId, method: 'template.getMany' })
+        } catch (err) {
+          logEmitter.emit('warning', `Skipping Templates export: ${err.message}`)
+          ctx.data.templates = []
+        }
+      }),
+      skip: () => !includeExperienceOrchestration
+    },
+    {
+      title: 'Fetching Data Assemblies data',
+      task: wrapTask(async (ctx) => {
+        try {
+          ctx.data.dataAssemblies = await cursorPagedGet({ client, spaceId, environmentId, method: 'dataAssembly.getMany' })
+        } catch (err) {
+          logEmitter.emit('warning', `Skipping Data Assemblies export: ${err.message}`)
+          ctx.data.dataAssemblies = []
+        }
+      }),
+      skip: () => !includeExperienceOrchestration
+    },
+    {
+      title: 'Fetching Fragments data',
+      task: wrapTask(async (ctx) => {
+        try {
+          ctx.data.fragments = await cursorPagedGet({ client, spaceId, environmentId, method: 'fragment.getMany' })
+        } catch (err) {
+          logEmitter.emit('warning', `Skipping Fragments export: ${err.message}`)
+          ctx.data.fragments = []
+        }
+      }),
+      skip: () => !includeExperienceOrchestration
+    },
+    {
+      title: 'Fetching Experiences data',
+      task: wrapTask(async (ctx) => {
+        try {
+          ctx.data.experiences = await cursorPagedGet({ client, spaceId, environmentId, method: 'experience.getMany' })
+        } catch (err) {
+          logEmitter.emit('warning', `Skipping Experiences export: ${err.message}`)
+          ctx.data.experiences = []
+        }
+      }),
+      skip: () => !includeExperienceOrchestration
     }
   ], listrOptions)
 }
@@ -173,6 +246,29 @@ function getEditorInterfaces (contentTypes) {
   }, {
     concurrency: 6
   })
+}
+
+/**
+ * Gets all ExO entities using cursor-based pagination (pageNext/pagePrev tokens).
+ * ExO list endpoints do not support skip-based pagination or the order param.
+ */
+async function cursorPagedGet ({ client, spaceId, environmentId, method }) {
+  const [entity, operation] = method.split('.')
+  const allItems = []
+  let pageNext = null
+
+  do {
+    const query = { spaceId, environmentId, limit: pageLimit }
+    if (pageNext) {
+      query.pageNext = pageNext
+    }
+    const response = await client[entity][operation](query)
+    allItems.push(...response.items)
+    logEmitter.emit('info', `Fetched ${allItems.length} ${entity} items`)
+    pageNext = response.pages?.next ?? null
+  } while (pageNext)
+
+  return allItems
 }
 
 /**

--- a/lib/tasks/init-client.js
+++ b/lib/tasks/init-client.js
@@ -27,3 +27,11 @@ export default function initClient (opts, useCda = false) {
   }
   return createCmaClient(config, { type: 'legacy' })
 }
+
+export function initPlainClient (opts) {
+  return createCmaClient({
+    accessToken: opts.managementToken,
+    host: opts.host,
+    logHandler
+  })
+}

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -126,6 +126,11 @@ export default yargs
     type: 'boolean',
     default: false
   })
+  .option('include-experience-orchestration', {
+    describe: 'Include Experience Orchestration entities (Component Types, Templates, Data Assemblies, Fragments, Experiences, Design Tokens). Requires exo_m1 entitlement on the source space.',
+    type: 'boolean',
+    default: false
+  })
   .option('header', {
     alias: 'H',
     type: 'string',

--- a/types.d.ts
+++ b/types.d.ts
@@ -28,9 +28,10 @@ export interface Options {
   skipWebhooks?: boolean;
   skipTags?: boolean;
   useVerboseRenderer?: boolean;
+  includeExperienceOrchestration?: boolean;
 }
 
-type ContentfulExportField = 'contentTypes' | 'entries' | 'assets' | 'locales' | 'tags' | 'webhooks' | 'roles' | 'editorInterfaces';
+type ContentfulExportField = 'contentTypes' | 'entries' | 'assets' | 'locales' | 'tags' | 'webhooks' | 'roles' | 'editorInterfaces' | 'designTokens' | 'componentTypes' | 'templates' | 'dataAssemblies' | 'fragments' | 'experiences';
 
 declare const runContentfulExport: (params: Options) => Promise<Record<ContentfulExportField, unknown[]>>
 export default runContentfulExport


### PR DESCRIPTION
## Summary

- Adds `--include-experience-orchestration` CLI flag (opt-in, defaults to false)
- Implements cursor-based pagination helper `cursorPagedGet()` for ExO list endpoints (which use `pageNext`/`pagePrev` tokens instead of skip-based pagination)
- Adds 6 Listr tasks to `get-space-data.js` for fetching all ExO entities: ComponentTypes, Templates, DataAssemblies, Fragments, Experiences, DesignTokens — each with graceful degradation (logs a warning and returns `[]` if the endpoint is unavailable)
- Extends `Options` type and `ContentfulExportField` type in `types.d.ts`

## Status

🚧 Draft — blocked on `contentful-management` `feat/exo` branch being released to npm before individual entity fetch tasks (AIS-120–125) can be wired up.

Related tickets: AIS-117 (cursor pagination), AIS-119 (CLI flag)

## Test plan

- [ ] Unit tests for `cursorPagedGet()` pagination logic
- [ ] Integration test: export with `--include-experience-orchestration` from a space with ExO data
- [ ] Verify graceful degradation when ExO is not enabled on a space

🤖 Generated with [Claude Code](https://claude.ai/claude-code)