### PR TITLE
fix: improve error handling and logging for asset downloads and tags [AIS-159]

### DIFF
--- a/lib/tasks/download-assets.js
+++ b/lib/tasks/download-assets.js
@@ -17,8 +17,8 @@ const streamPipeline = promisify(pipeline)
  * @param {import('axios').AxiosInstance} options.httpClient - The HTTP client to use for downloading the asset.
  * @param {string} options.assetId - The ID of the asset being downloaded, used in error messages.
  */
-async function downloadAsset ({ url, directory, httpClient, assetId }) {
-// handle urls without protocol
+async function downloadAsset({ url, directory, httpClient, assetId }) {
+  // handle urls without protocol
   if (url.startsWith('//')) {
     url = 'https:' + url
   }
@@ -54,7 +54,7 @@ async function downloadAsset ({ url, directory, httpClient, assetId }) {
   }
 }
 
-export default function downloadAssets (options) {
+export default function downloadAssets(options) {
   return (ctx, task) => {
     let successCount = 0
     let warningCount = 0
@@ -104,7 +104,7 @@ export default function downloadAssets (options) {
           })
           .catch((error) => {
             logEmitter.emit('warning', error.message)
-            task.output = `${figures.cross} ${error.message}`
+            task.output = `${figures.cross} error downloading ${url}: ${error.message}`
             errorCount++
           })
       })

--- a/lib/tasks/download-assets.js
+++ b/lib/tasks/download-assets.js
@@ -7,11 +7,13 @@ import { pipeline } from 'stream'
 import { promisify } from 'util'
 import { calculateExpiryTimestamp, isEmbargoedAsset, signUrl } from '../utils/embargoedAssets'
 import axios from 'axios'
+import axiosRetry from 'axios-retry'
 
 const streamPipeline = promisify(pipeline)
 
 // For streaming responses, axios timeout applies to time-to-first-byte, not total transfer duration
 const DEFAULT_DOWNLOAD_TIMEOUT_MS = 30_000
+const DEFAULT_RETRY_LIMIT = 3
 
 /**
  * @param {Object} options - The options for downloading the asset.
@@ -69,6 +71,18 @@ export default function downloadAssets(options) {
       httpAgent: options.httpAgent,
       httpsAgent: options.httpsAgent,
       proxy: options.proxy
+    })
+
+    axiosRetry(httpClient, {
+      retries: options.retryLimit ?? DEFAULT_RETRY_LIMIT,
+      retryDelay: axiosRetry.exponentialDelay,
+      shouldResetTimeout: true,
+      retryCondition: (error) =>
+        axiosRetry.isNetworkOrIdempotentRequestError(error) || error.response?.status === 429,
+      onRetry: (retryCount, error) => {
+        const status = error.response ? `HTTP ${error.response.status}` : (error.code || error.message)
+        logEmitter.emit('warning', `Asset download failed (${status}), retrying (attempt ${retryCount})...`)
+      }
     })
 
     return Promise.map(ctx.data.assets, (asset) => {

--- a/lib/tasks/download-assets.js
+++ b/lib/tasks/download-assets.js
@@ -1,5 +1,5 @@
 import Promise from 'bluebird'
-import { getEntityName } from 'contentful-batch-libs'
+import { getEntityName, logEmitter } from 'contentful-batch-libs'
 import figures from 'figures'
 import { createWriteStream, promises as fs } from 'fs'
 import path from 'path'
@@ -16,7 +16,7 @@ const streamPipeline = promisify(pipeline)
  * @param {string} options.directory - The directory where the asset should be saved.
  * @param {import('axios').AxiosInstance} options.httpClient - The HTTP client to use for downloading the asset.
  */
-async function downloadAsset ({ url, directory, httpClient }) {
+async function downloadAsset ({ url, directory, httpClient, assetId }) {
 // handle urls without protocol
   if (url.startsWith('//')) {
     url = 'https:' + url
@@ -46,7 +46,10 @@ async function downloadAsset ({ url, directory, httpClient }) {
      * @type {import('axios').AxiosError}
      */
     const axiosError = e
-    throw new Error(`error response status: ${axiosError.response.status}`)
+    if (axiosError.response) {
+      throw new Error(`error downloading asset ${assetId} (${url}): HTTP ${axiosError.response.status} ${axiosError.response.statusText}`, { cause: axiosError })
+    }
+    throw new Error(`error downloading asset ${assetId} (${url}): ${e.message}`, { cause: e })
   }
 }
 
@@ -81,14 +84,15 @@ export default function downloadAssets (options) {
           return Promise.resolve()
         }
 
-        let startingPromise = Promise.resolve({ url, directory: options.exportDir, httpClient })
+        const assetId = asset.sys.id
+        let startingPromise = Promise.resolve({ url, directory: options.exportDir, httpClient, assetId })
 
         if (isEmbargoedAsset(url)) {
           const { host, accessToken, spaceId, environmentId } = options
           const expiresAtMs = calculateExpiryTimestamp()
 
           startingPromise = signUrl(host, accessToken, spaceId, environmentId, url, expiresAtMs, httpClient)
-            .then((signedUrl) => ({ url: signedUrl, directory: options.exportDir, httpClient }))
+            .then((signedUrl) => ({ url: signedUrl, directory: options.exportDir, httpClient, assetId }))
         }
 
         return startingPromise
@@ -98,7 +102,9 @@ export default function downloadAssets (options) {
             successCount++
           })
           .catch((error) => {
-            task.output = `${figures.cross} error downloading ${url}: ${error.message}`
+            const message = `error downloading asset ${asset.sys.id} (${url}): ${error.message}`
+            logEmitter.emit('error', message)
+            task.output = `${figures.cross} ${message}`
             errorCount++
           })
       })

--- a/lib/tasks/download-assets.js
+++ b/lib/tasks/download-assets.js
@@ -10,6 +10,9 @@ import axios from 'axios'
 
 const streamPipeline = promisify(pipeline)
 
+// For streaming responses, axios timeout applies to time-to-first-byte, not total transfer duration
+const DEFAULT_DOWNLOAD_TIMEOUT_MS = 30_000
+
 /**
  * @param {Object} options - The options for downloading the asset.
  * @param {string} options.url - The URL of the asset to download.
@@ -62,7 +65,7 @@ export default function downloadAssets(options) {
 
     const httpClient = axios.create({
       headers: options.headers,
-      timeout: options.timeout,
+      timeout: options.timeout ?? DEFAULT_DOWNLOAD_TIMEOUT_MS,
       httpAgent: options.httpAgent,
       httpsAgent: options.httpsAgent,
       proxy: options.proxy

--- a/lib/tasks/download-assets.js
+++ b/lib/tasks/download-assets.js
@@ -103,9 +103,8 @@ export default function downloadAssets (options) {
             successCount++
           })
           .catch((error) => {
-            const message = `error downloading asset ${asset.sys.id} (${url}): ${error.message}`
-            logEmitter.emit('error', message)
-            task.output = `${figures.cross} ${message}`
+            logEmitter.emit('warning', error.message)
+            task.output = `${figures.cross} ${error.message}`
             errorCount++
           })
       })

--- a/lib/tasks/download-assets.js
+++ b/lib/tasks/download-assets.js
@@ -15,6 +15,7 @@ const streamPipeline = promisify(pipeline)
  * @param {string} options.url - The URL of the asset to download.
  * @param {string} options.directory - The directory where the asset should be saved.
  * @param {import('axios').AxiosInstance} options.httpClient - The HTTP client to use for downloading the asset.
+ * @param {string} options.assetId - The ID of the asset being downloaded, used in error messages.
  */
 async function downloadAsset ({ url, directory, httpClient, assetId }) {
 // handle urls without protocol

--- a/lib/tasks/download-assets.js
+++ b/lib/tasks/download-assets.js
@@ -67,14 +67,14 @@ export default function downloadAssets(options) {
 
     const httpClient = axios.create({
       headers: options.headers,
-      timeout: options.timeout ?? DEFAULT_DOWNLOAD_TIMEOUT_MS,
+      timeout: DEFAULT_DOWNLOAD_TIMEOUT_MS,
       httpAgent: options.httpAgent,
       httpsAgent: options.httpsAgent,
       proxy: options.proxy
     })
 
     axiosRetry(httpClient, {
-      retries: options.retryLimit ?? DEFAULT_RETRY_LIMIT,
+      retries: DEFAULT_RETRY_LIMIT,
       retryDelay: axiosRetry.exponentialDelay,
       shouldResetTimeout: true,
       retryCondition: (error) =>

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -68,7 +68,8 @@ export default function getFullSourceSpace ({
           .then((items) => {
             ctx.data.tags = items
           })
-          .catch(() => {
+          .catch((err) => {
+            logEmitter.emit('warning', `Fetching tags failed — tags will be empty in the export. Error: ${err.message}`)
             ctx.data.tags = []
           })
       }),
@@ -168,7 +169,7 @@ function getEditorInterfaces (contentTypes) {
       .catch(() => {
       // old contentTypes may not have an editor interface but we'll handle in a later stage
       // but it should not stop getting the data process
-        logEmitter.emit('warning', `No editor interface found for ${contentType}`)
+        logEmitter.emit('warning', `No editor interface found for ${contentType.name || contentType.sys.id}`)
         return Promise.resolve(null)
       })
   }, {

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -70,7 +70,8 @@ export default function getFullSourceSpace ({
           .then((items) => {
             ctx.data.tags = items
           })
-          .catch(() => {
+          .catch((err) => {
+            logEmitter.emit('warning', `Fetching tags failed — tags will be empty in the export. Error: ${err.message}`)
             ctx.data.tags = []
           })
       }),
@@ -242,7 +243,7 @@ function getEditorInterfaces (contentTypes) {
       .catch(() => {
       // old contentTypes may not have an editor interface but we'll handle in a later stage
       // but it should not stop getting the data process
-        logEmitter.emit('warning', `No editor interface found for ${contentType}`)
+        logEmitter.emit('warning', `No editor interface found for ${contentType.name || contentType.sys.id}`)
         return Promise.resolve(null)
       })
   }, {

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -71,8 +71,8 @@ export default function getFullSourceSpace ({
             ctx.data.tags = items
           })
           .catch((err) => {
-            logEmitter.emit('warning', `Fetching tags failed — tags will be empty in the export. Error: ${err.message}`)
-            ctx.data.tags = []
+            logEmitter.emit('error', new Error(`Fetching tags failed: ${err.message}`, { cause: err }))
+            throw err
           })
       }),
       skip: () => skipTags

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.5",
+        "axios-retry": "^4.5.0",
         "bfj": "^9.1.3",
         "bluebird": "^3.3.3",
         "cli-table3": "^0.6.0",
@@ -4778,6 +4779,18 @@
         "form-data": "^4.0.5",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
       }
     },
     "node_modules/axios/node_modules/agent-base": {
@@ -9888,6 +9901,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-set": {
@@ -17655,16 +17680,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "axios": "^1.13.5",
+        "axios-retry": "^4.5.0",
         "bfj": "^9.1.3",
         "bluebird": "^3.3.3",
         "cli-table3": "^0.6.0",
@@ -4758,6 +4759,18 @@
         "form-data": "^4.0.5",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-4.5.0.tgz",
+      "integrity": "sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "is-retry-allowed": "^2.2.0"
+      },
+      "peerDependencies": {
+        "axios": "0.x || 1.x"
       }
     },
     "node_modules/axios/node_modules/agent-base": {
@@ -9868,6 +9881,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-set": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "dependencies": {
     "axios": "^1.13.5",
+    "axios-retry": "^4.5.0",
     "bfj": "^9.1.3",
     "bluebird": "^3.3.3",
     "cli-table3": "^0.6.0",

--- a/test/unit/tasks/download-assets.test.js
+++ b/test/unit/tasks/download-assets.test.js
@@ -67,7 +67,7 @@ nock(`https://${API_HOST}`)
   .times(1)
   .reply(200, { policy: POLICY, secret: SECRET })
 
-function getAssets ({ existing = 0, nonExisting = 0, missingUrl = 0, embargoed = 0, unicodeShort = 0, unicodeLong = 0, differentFilename = 0 } = {}) {
+function getAssets({ existing = 0, nonExisting = 0, missingUrl = 0, embargoed = 0, unicodeShort = 0, unicodeLong = 0, differentFilename = 0 } = {}) {
   const existingUrl = `${BASE_PATH}${EXISTING_ASSET_URL}`
   const embargoedUrl = `${BASE_PATH_SECURE}${EMBARGOED_ASSET_URL}`
   const nonExistingUrl = `${BASE_PATH}${NON_EXISTING_URL}`
@@ -329,7 +329,7 @@ test('it doesn\'t use fileStack url as fallback for the file url and throws a wa
 
       const missingUrlsOutputCount = output.mock.calls.filter(call =>
         call[0]?.endsWith('asset.fields.file[en-US].url') ||
-          call[0]?.endsWith('asset.fields.file[de-DE].url'))
+        call[0]?.endsWith('asset.fields.file[de-DE].url'))
 
       expect(missingUrlsOutputCount).toHaveLength(2)
     })

--- a/test/unit/tasks/download-assets.test.js
+++ b/test/unit/tasks/download-assets.test.js
@@ -35,7 +35,7 @@ let output
 
 nock(`https:${BASE_PATH}`)
   .get(EXISTING_ASSET_URL)
-  .times(8)
+  .times(10)
   .reply(200)
 
 nock(`https:${BASE_PATH}`)
@@ -386,6 +386,27 @@ test('Downloads assets with long Unicode filenames', () => {
       const unicodeLongAsset = ctx.data.assets.find(asset => asset.sys.id === 'unicode long asset 0')
       expect(unicodeLongAsset.fields.file['en-US'].fileName).toBe(UNICODE_LONG_FILENAME)
       expect(unicodeLongAsset.fields.file['de-DE'].fileName).toBe(UNICODE_LONG_FILENAME)
+    })
+})
+
+test('Respects user-supplied timeout option', () => {
+  const task = downloadAssets({
+    exportDir: tmpDirectory,
+    timeout: 60_000
+  })
+  const ctx = {
+    data: {
+      assets: [...getAssets({ existing: 1 })]
+    }
+  }
+
+  return task(ctx, taskProxy)
+    .then(() => {
+      expect(ctx.assetDownloads).toEqual({
+        successCount: 2,
+        warningCount: 0,
+        errorCount: 0
+      })
     })
 })
 

--- a/test/unit/tasks/download-assets.test.js
+++ b/test/unit/tasks/download-assets.test.js
@@ -35,7 +35,7 @@ let output
 
 nock(`https:${BASE_PATH}`)
   .get(EXISTING_ASSET_URL)
-  .times(10)
+  .times(8)
   .reply(200)
 
 nock(`https:${BASE_PATH}`)
@@ -386,27 +386,6 @@ test('Downloads assets with long Unicode filenames', () => {
       const unicodeLongAsset = ctx.data.assets.find(asset => asset.sys.id === 'unicode long asset 0')
       expect(unicodeLongAsset.fields.file['en-US'].fileName).toBe(UNICODE_LONG_FILENAME)
       expect(unicodeLongAsset.fields.file['de-DE'].fileName).toBe(UNICODE_LONG_FILENAME)
-    })
-})
-
-test('Respects user-supplied timeout option', () => {
-  const task = downloadAssets({
-    exportDir: tmpDirectory,
-    timeout: 60_000
-  })
-  const ctx = {
-    data: {
-      assets: [...getAssets({ existing: 1 })]
-    }
-  }
-
-  return task(ctx, taskProxy)
-    .then(() => {
-      expect(ctx.assetDownloads).toEqual({
-        successCount: 2,
-        warningCount: 0,
-        errorCount: 0
-      })
     })
 })
 

--- a/test/unit/tasks/download-assets.test.js
+++ b/test/unit/tasks/download-assets.test.js
@@ -3,6 +3,7 @@ import { tmpdir } from 'os'
 import { resolve } from 'path'
 
 import nock from 'nock'
+import figures from 'figures'
 
 import downloadAssets from '../../../lib/tasks/download-assets'
 
@@ -22,6 +23,10 @@ const UNICODE_LONG_FILENAME = `${'测试文件'.repeat(10)}.jpg`
 const UNICODE_LONG_URL = `${ASSET_PATH}/${encodeURIComponent(UNICODE_LONG_FILENAME)}`
 const DIFFERENT_FILENAME = 'different filename.jpg'
 const UPLOAD_URL = '//file-stack-url-do-not-use-me.png'
+const NETWORK_ERROR_FILENAME = 'network-error.png'
+const NETWORK_ERROR_URL = `${ASSET_PATH}/${NETWORK_ERROR_FILENAME}`
+const RETRY_ASSET_FILENAME = 'retry-me.png'
+const RETRY_ASSET_URL = `${ASSET_PATH}/${RETRY_ASSET_FILENAME}`
 
 const API_HOST = 'api.contentful.com'
 const SPACE_ID = 'kq9lln4hyr8s'
@@ -66,6 +71,22 @@ nock(`https://${API_HOST}`)
   })
   .times(1)
   .reply(200, { policy: POLICY, secret: SECRET })
+
+// Simulates a network error with no HTTP response (e.g. ECONNRESET), for both locales
+const networkError = new Error('socket hang up')
+networkError.code = 'ECONNRESET'
+nock(`https:${BASE_PATH}`)
+  .get(NETWORK_ERROR_URL)
+  .times(2)
+  .replyWithError(networkError)
+
+// First attempt fails with a retryable 503, second attempt (the retry) succeeds
+nock(`https:${BASE_PATH}`)
+  .get(RETRY_ASSET_URL)
+  .reply(503)
+nock(`https:${BASE_PATH}`)
+  .get(RETRY_ASSET_URL)
+  .reply(200)
 
 function getAssets({ existing = 0, nonExisting = 0, missingUrl = 0, embargoed = 0, unicodeShort = 0, unicodeLong = 0, differentFilename = 0 } = {}) {
   const existingUrl = `${BASE_PATH}${EXISTING_ASSET_URL}`
@@ -415,5 +436,90 @@ test('Downloads assets with different filename than URL path', () => {
       expect(differentFilenameAsset.fields.file['en-US'].url).toBe(`${BASE_PATH}${EXISTING_ASSET_URL}`)
       expect(differentFilenameAsset.fields.file['de-DE'].fileName).toBe(DIFFERENT_FILENAME)
       expect(differentFilenameAsset.fields.file['de-DE'].url).toBe(`${BASE_PATH}${EXISTING_ASSET_URL}`)
+    })
+})
+
+test('Reports a clear error, not a TypeError, when there is no HTTP response', () => {
+  const task = downloadAssets({
+    exportDir: tmpDirectory
+  })
+  const networkErrorUrl = `${BASE_PATH}${NETWORK_ERROR_URL}`
+  const ctx = {
+    data: {
+      assets: [
+        {
+          sys: {
+            id: 'network error asset 0'
+          },
+          fields: {
+            file: {
+              'en-US': {
+                url: networkErrorUrl,
+                fileName: NETWORK_ERROR_FILENAME,
+                upload: UPLOAD_URL
+              },
+              'de-DE': {
+                url: networkErrorUrl,
+                fileName: NETWORK_ERROR_FILENAME,
+                upload: UPLOAD_URL
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  return task(ctx, taskProxy)
+    .then(() => {
+      expect(ctx.assetDownloads).toEqual({
+        successCount: 0,
+        warningCount: 0,
+        errorCount: 2
+      })
+      expect(output.mock.calls).toHaveLength(2)
+
+      for (const [message] of output.mock.calls) {
+        expect(message).not.toContain('TypeError')
+        expect(message).toContain('network error asset 0')
+      }
+    })
+})
+
+test('Retries a transient failure and succeeds without logging an error', () => {
+  const task = downloadAssets({
+    exportDir: tmpDirectory
+  })
+  const retryAssetUrl = `${BASE_PATH}${RETRY_ASSET_URL}`
+  const ctx = {
+    data: {
+      assets: [
+        {
+          sys: {
+            id: 'retry asset 0'
+          },
+          fields: {
+            file: {
+              'en-US': {
+                url: retryAssetUrl,
+                fileName: RETRY_ASSET_FILENAME,
+                upload: UPLOAD_URL
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+
+  return task(ctx, taskProxy)
+    .then(() => {
+      expect(ctx.assetDownloads).toEqual({
+        successCount: 1,
+        warningCount: 0,
+        errorCount: 0
+      })
+      expect(output.mock.calls).toHaveLength(1)
+      expect(output.mock.calls[0][0]).toContain(`${figures.tick} downloaded`)
     })
 })

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -489,6 +489,42 @@ test('Gets whole destination content and detects missing editor interfaces', () 
     })
 })
 
+test('Logs the content type name, or falls back to sys.id, when no editor interface is found', () => {
+  getEditorInterface.mockImplementation(() => Promise.reject(new Error('No editor interface found')))
+  mockEnvironment.getContentTypes.mockImplementation(() => Promise.resolve({
+    items: [
+      { sys: { id: 'named-content-type' }, name: 'Named Content Type', getEditorInterface },
+      { sys: { id: 'unnamed-content-type' }, getEditorInterface }
+    ],
+    total: 2
+  }))
+
+  const warnings = []
+  const onWarning = (message) => warnings.push(message)
+  logEmitter.on('warning', onWarning)
+
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    skipContent: true,
+    skipWebhooks: true,
+    skipRoles: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      expect(response.data.editorInterfaces).toHaveLength(0)
+      expect(warnings).toContain('No editor interface found for Named Content Type')
+      expect(warnings).toContain('No editor interface found for unnamed-content-type')
+      expect(warnings.some((message) => message.includes('[object Object]'))).toBe(false)
+    })
+    .finally(() => {
+      logEmitter.off('warning', onWarning)
+    })
+})
+
 test('Skips editor interfaces since no content types are found', () => {
   mockEnvironment.getContentTypes.mockImplementation(() => Promise.resolve({
     items: [],

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -1,3 +1,4 @@
+import { logEmitter } from 'contentful-batch-libs'
 import getSpaceData from '../../../lib/tasks/get-space-data'
 
 const maxAllowedLimit = 100
@@ -331,6 +332,38 @@ test('Gets whole destination content without tags', () => {
       expect(response.data.webhooks).toHaveLength(resultItemCount)
       expect(response.data.roles).toHaveLength(resultItemCount)
       expect(response.data.editorInterfaces).toHaveLength(resultItemCount)
+    })
+})
+
+test('Aborts the export when fetching tags fails', () => {
+  mockEnvironment.getTags = jest.fn(() => Promise.reject(new Error('tags service unavailable')))
+
+  // Production always calls setupLogging() before any task runs, which
+  // registers a permanent 'error' listener. Without one, Node treats a
+  // listener-less 'error' emit as unhandled and throws its own wrapper error.
+  const errors = []
+  const onError = (err) => errors.push(err)
+  logEmitter.on('error', onError)
+
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit
+  })
+    .run({
+      data: {}
+    })
+    .then(
+      () => Promise.reject(new Error('Expected the export to reject when tags fails')),
+      (err) => {
+        expect(err.message).toContain('tags service unavailable')
+        expect(errors).toHaveLength(1)
+        expect(errors[0].message).toBe('Fetching tags failed: tags service unavailable')
+        expect(errors[0].cause.message).toBe('tags service unavailable')
+      }
+    )
+    .finally(() => {
+      logEmitter.off('error', onError)
     })
 })
 


### PR DESCRIPTION
[AIS-97](https://contentful.atlassian.net/browse/AIS-97)

## Summary

Addresses all five Tier 1 bug fixes from AIS-97 — silent failures and crashes in asset downloads and space data fetching.

- Fix TypeError crash in \`downloadAsset\` when there is no HTTP response (ECONNRESET, DNS failure, timeout) — previously \`axiosError.response.status\` threw unconditionally, masking the real error
- Include asset ID, URL, HTTP status, and original error message in all download failure messages; emit failures via \`logEmitter\` so they land in the error log file rather than only flashing in task output
- Add default 30s timeout to asset downloads — \`options.timeout\` was \`undefined\` by default, causing axios to never time out on hung connections. Hardcoded rather than exposed as a config option, since there's no CLI flag for it yet.
- Add retry logic to asset downloads via \`axios-retry\` — 3 attempts with exponential backoff, retrying on network errors, 5xx, and 429; logs a warning on each retry via \`logEmitter\`
- Fix silent tags API failure — catch handler now logs the error and re-throws, aborting the export (matching how content types/entries/assets already behave on failure), instead of silently degrading to an empty array with no log at all
- Fix editor interface warning logging \`[object Object]\` — template literal now uses \`contentType.name || contentType.sys.id\`

| File | Fix | Ticket |
|------|-----|--------|
| \`download-assets.js\` | Fixed TypeError crash when HTTP response is absent — guards on \`axiosError.response\`, wraps both error paths with asset ID + URL + original error as \`{ cause }\` | AIS-157 |
| \`download-assets.js\` | Threaded \`assetId\` through download options so all error messages include the asset ID | AIS-157 |
| \`download-assets.js\` | Added \`logEmitter\` import and emit error from the catch handler — failures now land in the error log file, not just flash in the Listr spinner | AIS-157 |
| \`download-assets.js\` | Added default 30s timeout (\`DEFAULT_DOWNLOAD_TIMEOUT_MS\`) — applies to time-to-first-byte, so large file transfers are unaffected. Hardcoded, not user-configurable (no CLI flag exists) | AIS-158 |
| \`download-assets.js\` | Added \`axios-retry\` with exponential backoff (\`DEFAULT_RETRY_LIMIT\` = 3, hardcoded); retries on network errors, 5xx, and 429; logs a warning per retry | AIS-161 |
| \`get-space-data.js\` | Tags catch handler now logs the error and re-throws, aborting the export — same behavior as content types/entries/assets on failure | AIS-159 |
| \`get-space-data.js\` | Fixed editor interface warning logging \`[object Object]\` → \`contentType.name \|\| contentType.sys.id\` | AIS-160 |

## Test plan
- [ ] Simulate ECONNRESET during asset download — verify error message includes asset ID, URL, and original error; verify it appears in the error log file
- [ ] Simulate HTTP 404/500 during asset download — verify error message includes asset ID, URL, and HTTP status + statusText
- [ ] Simulate a transient 503 during asset download — verify retry warnings are logged and the download eventually succeeds
- [ ] Simulate a hung connection (no response) — verify the 30s timeout fires and the error is logged with asset ID and URL
- [ ] Run export against a space with tags — verify tags export successfully
- [ ] Temporarily break the tags API (invalid token, etc.) — verify the error is logged and the export aborts (matching content types/entries/assets failure behavior)
- [ ] Verify editor interface warning log shows content type name/ID instead of \`[object Object]\`
- [ ] Verify asset download error count in end-of-run summary table still increments correctly

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-97]: https://contentful.atlassian.net/browse/AIS-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
