### PR TITLE
Include exo default true [AIS-96]

### DIFF
--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -129,7 +129,7 @@ export default yargs
   .option('include-experience-orchestration', {
     describe: 'Include Experience Orchestration entities (Component Types, Templates, Data Assemblies, Fragments, Experiences, Design Tokens). Requires exo_m1 entitlement on the source space.',
     type: 'boolean',
-    default: false
+    default: true
   })
   .option('header', {
     alias: 'H',


### PR DESCRIPTION
## Summary
`include-experience-orchestration` param should be enabled by default

