### PR TITLE
feat: export Design Tokens as part of ExO entity group [AIS-120]

### DIFF
--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -158,8 +158,6 @@ export default function getFullSourceSpace ({
     },
     {
       title: 'Fetching Design Tokens data',
-      // NOTE: designToken is not yet implemented in the contentful-management SDK (feat/exo branch, AIS-135).
-      // This task will gracefully degrade to [] until the SDK is released and bumped (AIS-135).
       task: wrapTask(async (ctx) => {
         try {
           ctx.data.designTokens = await cursorPagedGet({ client: plainClient, spaceId, environmentId, method: 'designToken.getMany' })

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "cli-table3": "^0.6.0",
         "contentful": "^11.5.10",
         "contentful-batch-libs": "^12.0.0",
-        "contentful-management": "^12.10.0",
+        "contentful-management": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
         "date-fns": "^4.1.0",
         "figures": "^3.2.0",
         "jsonwebtoken": "^9.0.0",
@@ -6109,9 +6109,9 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "12.10.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.10.0.tgz",
-      "integrity": "sha512-pZKIJGCw9RwMrMxNrdTs5qeglkyMRkwvBWOREt5a0MiTJdLWrBPJ7tPXViNFS29Md8BqGiS3IWPCaXaiff2qjw==",
+      "version": "0.0.0-determined-by-semantic-release",
+      "resolved": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
+      "integrity": "sha512-9KLjhvqiaypvxRmc/jCu7LoZuydjjeDZEaiWQ/lkwdKXeFqhOrzMp/8nkJw6C4RDay5N8pBE1zvH1ZG/XPVlQw==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "cli-table3": "^0.6.0",
         "contentful": "^11.5.10",
         "contentful-batch-libs": "^12.0.0",
-        "contentful-management": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
+        "contentful-management": "^12.12.0",
         "date-fns": "^4.1.0",
         "figures": "^3.2.0",
         "jsonwebtoken": "^9.0.0",
@@ -6109,9 +6109,9 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "0.0.0-determined-by-semantic-release",
-      "resolved": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
-      "integrity": "sha512-9KLjhvqiaypvxRmc/jCu7LoZuydjjeDZEaiWQ/lkwdKXeFqhOrzMp/8nkJw6C4RDay5N8pBE1zvH1ZG/XPVlQw==",
+      "version": "12.12.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.12.0.tgz",
+      "integrity": "sha512-8K4jvWTUfBS+N8VoUKHolFktEi1i2pIBt2uFnPHhAkCeOfARDc4bjEeKizNoPcBL7T7W6YvS2KIJOUPKKHHxVQ==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cli-table3": "^0.6.0",
     "contentful": "^11.5.10",
     "contentful-batch-libs": "^12.0.0",
-    "contentful-management": "^12.10.0",
+    "contentful-management": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
     "date-fns": "^4.1.0",
     "figures": "^3.2.0",
     "jsonwebtoken": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "cli-table3": "^0.6.0",
     "contentful": "^11.5.10",
     "contentful-batch-libs": "^12.0.0",
-    "contentful-management": "file:../../.local-tarballs/contentful-management-0.0.0-determined-by-semantic-release.tgz",
+    "contentful-management": "^12.12.0",
     "date-fns": "^4.1.0",
     "figures": "^3.2.0",
     "jsonwebtoken": "^9.0.0",

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -24,11 +24,27 @@ function pagedContentResult (query, maxItems, mock = {}) {
   return result
 }
 
+// ExO endpoints use cursor-based pagination (pageNext token) instead of skip/limit.
+function cursorPagedResult (query, maxItems, mock = {}) {
+  const start = query.pageNext ? Number(query.pageNext) : 0
+  const end = Math.min(start + query.limit, maxItems)
+  const items = Array.from({ length: end - start }, (n) => {
+    const id = start + n + 1
+    return Object.assign({ sys: { id } }, mock)
+  })
+  return {
+    items,
+    pages: end < maxItems ? { next: String(end) } : {}
+  }
+}
+
 const mockSpace = {}
 
 const mockEnvironment = {}
 
 const mockClient = {}
+
+const mockPlainClient = { designToken: {} }
 
 const getEditorInterface = jest.fn()
 
@@ -62,6 +78,9 @@ function setupMocks () {
   mockSpace.getRoles = jest.fn((query) => {
     return Promise.resolve(pagedResult(query, resultItemCount))
   })
+  mockPlainClient.designToken.getMany = jest.fn((query) => {
+    return Promise.resolve(cursorPagedResult(query, resultItemCount))
+  })
   getEditorInterface.mockImplementation(() => Promise.resolve({}))
 }
 
@@ -76,6 +95,7 @@ afterEach(() => {
   mockEnvironment.getTags.mockClear()
   mockSpace.getWebhooks.mockClear()
   mockSpace.getRoles.mockClear()
+  mockPlainClient.designToken.getMany.mockClear()
   getEditorInterface.mockClear()
 })
 
@@ -563,6 +583,63 @@ test('halts fetching when no items in page', () => {
       expect(mockEnvironment.getLocales.mock.calls).toHaveLength(1)
       expect(mockEnvironment.getLocales.mock.calls[0][0].limit).toBe(1000)
       expect(mockEnvironment.getLocales.mock.calls[0][0].skip).toBe(0)
+    })
+})
+
+test('Skips Design Tokens when includeExperienceOrchestration is not set', () => {
+  return getSpaceData({
+    client: mockClient,
+    plainClient: mockPlainClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      expect(mockPlainClient.designToken.getMany.mock.calls).toHaveLength(0)
+      expect(response.data.designTokens).toBeUndefined()
+    })
+})
+
+test('Fetches Design Tokens via cursor pagination when includeExperienceOrchestration is set', () => {
+  return getSpaceData({
+    client: mockClient,
+    plainClient: mockPlainClient,
+    spaceId: 'spaceid',
+    environmentId: 'exo',
+    maxAllowedLimit,
+    includeExperienceOrchestration: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      expect(mockPlainClient.designToken.getMany.mock.calls).toHaveLength(Math.ceil(resultItemCount / maxAllowedLimit))
+      expect(mockPlainClient.designToken.getMany.mock.calls[0][0]).toMatchObject({
+        spaceId: 'spaceid',
+        environmentId: 'exo',
+        limit: maxAllowedLimit
+      })
+      expect(response.data.designTokens).toHaveLength(resultItemCount)
+    })
+})
+
+test('Gracefully degrades Design Tokens export to [] on failure', () => {
+  mockPlainClient.designToken.getMany = jest.fn(() => Promise.reject(new Error('Forbidden')))
+
+  return getSpaceData({
+    client: mockClient,
+    plainClient: mockPlainClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    includeExperienceOrchestration: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      expect(response.data.designTokens).toEqual([])
     })
 })
 


### PR DESCRIPTION
[AIS-120](https://contentful.atlassian.net/browse/AIS-120)

## Summary
- Wires up the `designToken` plain client (added in [AIS-352](https://contentful.atlassian.net/browse/AIS-352)) into the existing "Fetching Design Tokens data" task in `get-space-data.js`, which was previously blocked and gracefully degrading to `[]` pending SDK support. Removes the now-stale blocker comment.
- Adds unit test coverage for the task (skip when `includeExperienceOrchestration` unset, cursor-paginated fetch when set, graceful `[]` degrade on failure) — the first test coverage for any ExO entity task in this file (componentTypes/templates/dataAssemblies/fragments/experiences still have none).
- Bumps `contentful-management` to `^12.12.0`, which now ships DesignToken support natively — matches the pattern already used for the other 5 ExO entities.
- Verified end-to-end against a live sandbox space (`3fyh0othob6d`, `exo` environment): all 16 seeded design tokens exported correctly alongside the other ExO entities (29 componentTypes, 1 template, 9 dataAssemblies).

## Test plan
- [x] Unit tests pass (`npm run test:unit`)
- [x] Lint passes
- [x] Verified against live sandbox — design tokens export correctly alongside other ExO entities

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-120]: https://contentful.atlassian.net/browse/AIS-120?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIS-352]: https://contentful.atlassian.net/browse/AIS-352?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ