### PR TITLE
build(deps): upgrade actions/cache/save & actions/cache/restore from v4 -> v6

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,7 +30,7 @@ jobs:
         run: ls -la dist/
 
       - name: Save Build folders
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: |
             dist

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -33,7 +33,7 @@ jobs:
         run: npm ci
 
       - name: Restore the build folders
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: |
             dist

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
     secrets: inherit
 
   release:
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/exo')
     needs: [build, check]
     permissions:
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,7 +57,7 @@ jobs:
         run: npm ci
 
       - name: Restore the build folders
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: |
             dist

--- a/package.json
+++ b/package.json
@@ -109,6 +109,11 @@
         "name": "beta",
         "channel": "beta",
         "prerelease": true
+      },
+      {
+        "name": "exo",
+        "channel": "exo",
+        "prerelease": "exo"
       }
     ],
     "plugins": [


### PR DESCRIPTION
## Summary
As titled, really just forcing a new build of exo branch.

See [actions/cache changelog](https://github.com/actions/cache):

> v5
> Updated to node 24
> Requires a minimum Actions Runner version of 2.327.1

> v6
> Updated @actions/cache, @actions/core, @actions/exec to latest major versions
> Migrated to ESM module system

### Claude's take on why this is safe:
  Why it's safe:

  - All inputs used (path, key, fail-on-cache-miss) are core inputs that haven't changed across major versions of actions/cache
  - The cache/save + cache/restore subaction split (vs the monolithic actions/cache) has been stable since v3.3
  - fail-on-cache-miss: true was introduced in v3.3.0 — fully supported in v6
  - The cache key pattern (build-cache-${{ github.run_id }}-${{ github.run_attempt }}) is untouched, so cross-workflow cache hits will still work correctly

  No inputs were added, removed, or renamed between v4 and v6 that affect this usage. Good to merge.




<!-- Give a short summary what your PR is introducing/fixing. -->

## Description

<!-- Describe your changes in detail -->

## Motivation and Context

<!--
Why is this change required? What problem does it solve?
If it fixes an open issue, please link to the issue here.
-->

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes
