### PR TITLE
Integration tests for Experience Orchestration [AIS-133]

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -11,6 +11,8 @@ on:
         required: true
       EXPORT_SPACE_ID_EMBARGOED_ASSETS:
         required: true
+      EXPORT_ORGANIZATION_ID:
+        required: true
 
 jobs:
   check:
@@ -57,3 +59,4 @@ jobs:
           DELIVERY_TOKEN: ${{ secrets.DELIVERY_TOKEN }}
           EXPORT_SPACE_ID: ${{ secrets.EXPORT_SPACE_ID }}
           EXPORT_SPACE_ID_EMBARGOED_ASSETS: ${{ secrets.EXPORT_SPACE_ID_EMBARGOED_ASSETS }}
+          EXPORT_ORGANIZATION_ID: ${{ secrets.EXPORT_ORGANIZATION_ID }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Read this file first. It tells you where to find context in this repo.
 - **`package.json` version is `0.0.0-determined-by-semantic-release`.** Never set a version manually. `semantic-release` handles all versioning.
 - **Babel target (Node 12) is lower than `engines.node` (>=22).** This is a known inconsistency in `babel.config.json`. The low target is harmless but confusing.
 - **`contentOnly` flag is a shorthand.** When set, it internally enables `skipRoles`, `skipContentModel`, and `skipWebhooks`. Do not duplicate this logic.
+- **ExO entities Organization entitlement-gated.** `includeExperienceOrchestration` defaults to `true`. When enabled, six ExO entity types are fetched using the `plainClient`. If the space lacks the `exo_m1` entitlement, each fetch fails silently: the entity array is set to `[]` and a warning is emitted. The export does not abort. See [docs/exo-export.md](./docs/exo-export.md).
 - **Asset downloads use concurrency of 6.** Both `download-assets.js` and `get-space-data.js` (editor interfaces) use Bluebird `Promise.map` with `{ concurrency: 6 }`. Be careful about changing this -- it affects API rate limiting.
 
 ## High-Traffic Areas

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -24,7 +24,7 @@ graph TD
 | `lib/index.js` | Main entry point. Orchestrates the export pipeline using Listr tasks: init client, fetch space data, download assets, write export file. |
 | `lib/parseOptions.js` | Merges defaults, config file, and user-supplied params. Validates required fields (`spaceId`, `managementToken`). Processes proxy settings, query strings, and file paths. |
 | `lib/tasks/init-client.js` | Creates CMA and/or CDA client instances using `contentful-management` and `contentful` SDKs. |
-| `lib/tasks/get-space-data.js` | Paginated fetching of all entity types (content types, entries, assets, locales, tags, webhooks, roles, editor interfaces). Handles draft/archived filtering and tag stripping. |
+| `lib/tasks/get-space-data.js` | Paginated fetching of all entity types (content types, entries, assets, locales, tags, webhooks, roles, editor interfaces). Handles draft/archived filtering and tag stripping. Also fetches ExO entities (Design Tokens, Components, Experience Templates, Data Assemblies, Experience Fragments, Experiences) when `includeExperienceOrchestration` is enabled. |
 | `lib/tasks/download-assets.js` | Downloads asset binary files to disk with concurrency of 6. Handles embargoed (signed URL) assets. |
 | `lib/usageParams.js` | Yargs CLI argument definitions. Consumed by the `bin/contentful-export` CLI entry point. |
 | `lib/utils/embargoedAssets.js` | JWT-based URL signing for embargoed (secure) assets. Caches asset keys per space/environment. |
@@ -37,7 +37,7 @@ graph TD
 
 1. **Option parsing** -- User passes options (programmatic or CLI). `parseOptions` merges defaults, config file, and params. Validates required fields.
 2. **Client initialization** -- Creates a CMA client. If `deliveryToken` is provided (and `includeDrafts` is false), also creates a CDA client for fetching published-only entries/assets.
-3. **Paginated fetching** -- `get-space-data.js` connects to the space/environment, then fetches each entity type in sequence using `pagedGet` (page size = `maxAllowedLimit`, default 1000, ordered by `sys.createdAt,sys.id`). Entries and assets are post-filtered for drafts/archived status and optionally have tags stripped.
+3. **Paginated fetching** -- `get-space-data.js` connects to the space/environment, then fetches each entity type in sequence using `pagedGet` (page size = `maxAllowedLimit`, default 1000, ordered by `sys.createdAt,sys.id`). Entries and assets are post-filtered for drafts/archived status and optionally have tags stripped. If `includeExperienceOrchestration` is enabled, six ExO entity types are fetched using cursor-based pagination (`cursorPagedGet`, which follows `response.pages.next` tokens) via the plain CMA client. ExO fetch errors are caught per entity type — a failing endpoint logs a warning and yields `[]` rather than aborting the export.
 4. **Asset download** (optional) -- If `downloadAssets` is true, asset files are streamed to disk under `exportDir/<host>/<path>`. Embargoed assets are signed via the asset_keys API with a 6-hour expiry window before download.
 5. **JSON export** -- The aggregated data object is written to disk using `bfj` (Big-Friendly JSON) for streaming large JSON writes without exhausting memory.
 6. **Summary** -- A table of exported entity counts is printed, along with duration and file path.
@@ -52,6 +52,7 @@ graph TD
 | **Embargoed Assets** | Assets hosted on `*.secure.*` domains that require JWT-signed URLs for access. The tool creates short-lived signed URLs via the `asset_keys` API. |
 | **Draft / Archived** | Entries and assets can be in draft (no `publishedVersion`) or archived (`archivedVersion` set) states. By default, only published items are exported. |
 | **CDA vs CMA export** | CMA returns all versions (latest, including unpublished changes). CDA returns only the published version. Providing a `deliveryToken` switches entry/asset fetching to CDA. Tags are CMA-only and will not be exported via CDA. |
+| **Experience Orchestration (ExO)** | Six ExO entity types (Design Tokens, Components, Experience Templates, Data Assemblies, Experience Fragments, Experiences) are exported when `includeExperienceOrchestration: true` is set. Requires the `exo_m1` Organization entitlement. Non-entitled spaces return empty arrays rather than failing. See [docs/exo-export.md](./docs/exo-export.md). |
 
 ## Key Dependencies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,7 @@ Integration tests require these environment variables:
 - `DELIVERY_TOKEN` -- CDA API token
 - `EXPORT_SPACE_ID` -- Space ID for standard tests
 - `EXPORT_SPACE_ID_EMBARGOED_ASSETS` -- Space ID for embargoed asset tests
+- `EXPORT_ORGANIZATION_ID` -- Organization ID (must have the Experience Orchestration entitlement) used by `test/integration/export-exo.test.js` to provision and tear down its own throwaway space
 
 ## Code Style & Conventions
 

--- a/README.md
+++ b/README.md
@@ -216,6 +216,14 @@ Skip exporting webhooks
 
 Untag assets and entries
 
+#### `includeExperienceOrchestration` [boolean] [default: true]
+
+Export Experience Orchestration (ExO) entities: Design Tokens, Components, Experience Templates, Data Assemblies, Experience Fragments, and Experiences.
+
+Requires the Organization to have the `exo_m1` entitlement. If the Organization is not entitled, the export will not throw — each ExO array will be empty and a warning will be logged.
+
+See [docs/exo-export.md](./docs/exo-export.md) for full details.
+
 #### `contentOnly` [boolean] [default: false]
 
 Only export entries and assets
@@ -331,6 +339,19 @@ This is an overview of the exported data:
   "webhooks": [],
   "roles": [],
   "editorInterfaces": [],
+  "designTokens": [],
+  "components": [],
+  "experienceTemplates": [],
+  "dataAssemblies": [],
+  "experienceFragments": [],
+  "experiences": []
+}
+```
+
+When `includeExperienceOrchestration: true` is set, six additional arrays are included:
+
+```json
+{
   "designTokens": [],
   "components": [],
   "experienceTemplates": [],

--- a/docs/exo-export.md
+++ b/docs/exo-export.md
@@ -1,0 +1,64 @@
+# Experience Orchestration (ExO) Export
+
+## What is ExO?
+
+Experience Orchestration (ExO) is Contentful's system for composing and rendering structured page experiences. It sits above the traditional entry/content-type layer and provides six dedicated entity types — Design Tokens, Components, Experience Templates, Data Assemblies, Experience Fragments, and Experiences — that together describe how content is fetched, assembled, and laid out.
+
+## Enabling ExO export
+
+Pass `includeExperienceOrchestration: true` to `runContentfulExport`:
+
+```javascript
+import contentfulExport from 'contentful-export'
+
+const result = await contentfulExport({
+  spaceId: '<space_id>',
+  managementToken: '<management_token>',
+  includeExperienceOrchestration: true,
+})
+
+// result will contain:
+// result.designTokens       — array of Design Token entities
+// result.components         — array of Component entities
+// result.experienceTemplates — array of Experience Template entities
+// result.dataAssemblies     — array of Data Assembly entities
+// result.experienceFragments — array of Experience Fragment entities
+// result.experiences        — array of Experience entities
+```
+
+## Entitlement requirement
+
+ExO features must be enabled for a Contentful Organization. If an Organization does not have this entitlement, the CMA will reject ExO API calls. The export tool handles this gracefully:
+
+- Each ExO entity type is fetched independently, wrapped in a `try/catch`.
+- On failure, the entity array is set to `[]` and a warning is logged — the export continues and completes normally.
+- No error is thrown and the export is not aborted.
+
+This means you can safely pass `includeExperienceOrchestration: true` against any space. Non-entitled spaces produce empty arrays; entitled spaces produce the full entity lists.
+
+## Output structure
+
+The six ExO fields are appended to the standard export output:
+
+```json
+{
+  "contentTypes": [],
+  "entries": [],
+  "assets": [],
+  "locales": [],
+  "tags": [],
+  "webhooks": [],
+  "roles": [],
+  "editorInterfaces": [],
+  "designTokens": [],
+  "components": [],
+  "experienceTemplates": [],
+  "dataAssemblies": [],
+  "experienceFragments": [],
+  "experiences": []
+}
+```
+
+## Using ExO export output with contentful-import
+
+The six ExO arrays exported here are designed to be fed directly into `contentful-import` with `includeExperienceOrchestration: true`. Import handles ID preservation, dependency ordering (topological sort for Components and Fragments), and folder concept rewriting. See [contentful-import's ExO doc](https://github.com/contentful/contentful-import/blob/main/docs/exo-import.md) for import-side details.

--- a/test/integration/export-exo.test.js
+++ b/test/integration/export-exo.test.js
@@ -1,0 +1,368 @@
+import { join } from 'path'
+
+import mkdirp from 'mkdirp'
+import rimraf from 'rimraf'
+import { createClient } from 'contentful-management'
+
+import runContentfulExport from '../../dist/index'
+
+jest.setTimeout(180000)
+
+const tmpFolder = join(__dirname, 'tmp-exo')
+const managementToken = process.env.MANAGEMENT_TOKEN
+const organizationId = process.env.EXPORT_ORGANIZATION_ID
+
+const ENVIRONMENT_ID = 'master'
+const CONTENT_TYPE_ID = 'testPage'
+
+const EXO_URN_BASE = 'crn:contentful:::experience:spaces/$self/environments/$self'
+const CONTENT_URN_BASE = 'crn:contentful:::content:spaces/$self/environments/$self'
+
+const resourceLink = (linkType, urn) => ({ sys: { type: 'ResourceLink', linkType, urn } })
+const componentUrn = (id) => `${EXO_URN_BASE}/components/${id}`
+const fragmentUrn = (id) => `${EXO_URN_BASE}/experienceFragments/${id}`
+const dataAssemblyUrn = (id) => `${EXO_URN_BASE}/dataAssemblies/${id}`
+const entryUrn = (id) => `${CONTENT_URN_BASE}/entries/${id}`
+
+const VIEWPORT = { id: '_', query: '*', displayName: 'Default', previewSize: '1024px' }
+
+async function retry(fn, attempts = 5, delayMs = 2000) {
+  let lastErr
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn()
+    } catch (err) {
+      lastErr = err
+      await new Promise((resolve) => setTimeout(resolve, delayMs))
+    }
+  }
+  throw lastErr
+}
+
+const rootClient = createClient({ accessToken: managementToken })
+
+let spaceId
+let client
+let entryId
+const createdIds = {
+  designTokens: [],
+  components: [],
+  experienceTemplates: [],
+  dataAssemblies: [],
+  experienceFragments: [],
+  experiences: []
+}
+
+beforeAll(async () => {
+  mkdirp.sync(tmpFolder)
+
+  const space = await rootClient.space.create({ organizationId }, { name: 'contentful-export-exo-test' })
+  spaceId = space.sys.id
+  client = createClient({ accessToken: managementToken }, { defaults: { spaceId, environmentId: ENVIRONMENT_ID } })
+
+  // Content layer: a minimal content type + entry, used as the target of DataAssembly/
+  // contentBindings parameters, mirroring how real ExO spaces reference real content.
+  const contentType = await retry(() =>
+    client.contentType.createWithId(
+      { contentTypeId: CONTENT_TYPE_ID },
+      {
+        name: 'Test Page',
+        displayField: 'title',
+        fields: [
+          { id: 'title', name: 'Title', type: 'Symbol', required: false, localized: false },
+          { id: 'message', name: 'Message', type: 'Symbol', required: true, localized: false }
+        ]
+      }
+    )
+  )
+  const publishedContentType = await client.contentType.publish({ contentTypeId: contentType.sys.id }, contentType)
+
+  const entry = await client.entry.create(
+    { contentTypeId: publishedContentType.sys.id },
+    { fields: { title: { 'en-US': 'Test Page' }, message: { 'en-US': 'Page not found' } } }
+  )
+  const publishedEntry = await client.entry.publish({ entryId: entry.sys.id }, entry)
+  entryId = publishedEntry.sys.id
+
+  // Design Tokens (2) -- upserted, auto-published server-side.
+  const colorToken = await client.designToken.upsert(
+    { designTokenId: 'colorToken' },
+    { sys: { id: 'colorToken', type: 'DesignToken' }, name: 'Test Color Token', type: 'DTCG.Color' }
+  )
+  const secondColorToken = await client.designToken.upsert(
+    { designTokenId: 'secondColorToken' },
+    { sys: { id: 'secondColorToken', type: 'DesignToken' }, name: 'Test Secondary Color Token', type: 'DTCG.Color' }
+  )
+  createdIds.designTokens.push(colorToken.sys.id, secondColorToken.sys.id)
+
+  // Data Assemblies (2) -- each binds a parameter to an Entry of the content type above.
+  const assemblyA = await client.dataAssembly.create(
+    {},
+    {
+      sys: { type: 'DataAssembly', dataType: [{ id: 'message', name: 'Message', type: 'String', required: true }] },
+      metadata: { tags: [] },
+      name: 'Assembly A',
+      description: 'Test data assembly A',
+      parameters: {
+        p_entry: {
+          name: 'Entry',
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          allowedResources: [
+            { type: 'Contentful:Entry', source: 'crn:contentful:::content:spaces/$self/environments/$self', allowedTypes: [CONTENT_TYPE_ID] }
+          ]
+        }
+      },
+      resolvers: {
+        r_node: {
+          source: 'Contentful:GraphQL',
+          query: 'query ($id: ID!) { _node(id: $id) { __typename ... on TestPage { message } } }',
+          parameters: { id: '$parameters/p_entry' }
+        }
+      },
+      return: { message: { $from: { source: '$resolvers/r_node/_node', select: { $on: { type: { TestPage: 'message' } } } } } }
+    }
+  )
+  const publishedAssemblyA = await client.dataAssembly.publish({ dataAssemblyId: assemblyA.sys.id, version: assemblyA.sys.version })
+
+  const assemblyB = await client.dataAssembly.create(
+    {},
+    {
+      sys: { type: 'DataAssembly', dataType: [{ id: 'message', name: 'Message', type: 'String', required: true }] },
+      metadata: { tags: [] },
+      name: 'Assembly B',
+      description: 'Test data assembly B',
+      parameters: {
+        p_entry: {
+          name: 'Entry',
+          type: 'ResourceLink',
+          linkType: 'Contentful:Entry',
+          allowedResources: [
+            { type: 'Contentful:Entry', source: 'crn:contentful:::content:spaces/$self/environments/$self', allowedTypes: [CONTENT_TYPE_ID] }
+          ]
+        }
+      },
+      resolvers: {
+        r_node: {
+          source: 'Contentful:GraphQL',
+          query: 'query ($id: ID!) { _node(id: $id) { __typename ... on TestPage { message } } }',
+          parameters: { id: '$parameters/p_entry' }
+        }
+      },
+      return: { message: { $from: { source: '$resolvers/r_node/_node', select: { $on: { type: { TestPage: 'message' } } } } } }
+    }
+  )
+  const publishedAssemblyB = await client.dataAssembly.publish({ dataAssemblyId: assemblyB.sys.id, version: assemblyB.sys.version })
+  createdIds.dataAssemblies.push(publishedAssemblyA.sys.id, publishedAssemblyB.sys.id)
+
+  // Components (3) -- baseComponent (Slot placeholder) -> fragmentA -> compositeComponent
+  // (Component + ExperienceFragment tree nodes, DataAssembly link, DesignToken-backed design property).
+  const baseComponent = await client.component.create(
+    {},
+    {
+      name: 'Base Component',
+      description: 'Leaf component exercising a Slot placeholder',
+      viewports: [VIEWPORT],
+      contentProperties: [],
+      designProperties: [],
+      slots: [{ id: 'untitledSlot1', name: 'Untitled slot 1', required: false, validations: [] }],
+      componentTree: [{ id: 'slotNode1', nodeType: 'Slot', slotId: 'untitledSlot1' }],
+      metadata: { tags: [], concepts: [] }
+    }
+  )
+  const publishedBaseComponent = await client.component.publish({ componentId: baseComponent.sys.id, version: baseComponent.sys.version })
+
+  const leafComponent = await client.component.create(
+    {},
+    {
+      name: 'Leaf Component',
+      description: 'Component exercising a DesignToken-backed design property and a DataAssembly link',
+      viewports: [VIEWPORT],
+      contentProperties: [],
+      designProperties: [
+        {
+          id: 'dp_color',
+          name: 'Color',
+          type: 'DTCG.Color',
+          fallbackValue: { type: 'DesignToken', value: colorToken.sys.id },
+          allowedResources: [{ type: 'DesignToken', value: colorToken.sys.id }]
+        }
+      ],
+      dataAssemblies: [resourceLink('Contentful:DataAssembly', dataAssemblyUrn(publishedAssemblyA.sys.id))],
+      metadata: { tags: [], concepts: [] }
+    }
+  )
+  const publishedLeafComponent = await client.component.publish({ componentId: leafComponent.sys.id, version: leafComponent.sys.version })
+
+  const fragmentA = await client.experienceFragment.create(
+    {},
+    {
+      name: 'Fragment A',
+      description: 'Fragment wrapping the base component',
+      viewports: [VIEWPORT],
+      designProperties: {},
+      component: resourceLink('Contentful:Component', componentUrn(publishedBaseComponent.sys.id))
+    }
+  )
+  const publishedFragmentA = await client.experienceFragment.publish({ experienceFragmentId: fragmentA.sys.id, version: fragmentA.sys.version })
+
+  const compositeComponent = await client.component.create(
+    {},
+    {
+      name: 'Composite Component',
+      description: 'Component exercising Component -> Component and Component -> ExperienceFragment tree nodes',
+      viewports: [VIEWPORT],
+      contentProperties: [],
+      designProperties: [],
+      dataAssemblies: [resourceLink('Contentful:DataAssembly', dataAssemblyUrn(publishedAssemblyB.sys.id))],
+      componentTree: [
+        {
+          id: 'compNode1',
+          nodeType: 'Component',
+          component: resourceLink('Contentful:Component', componentUrn(publishedLeafComponent.sys.id)),
+          contentProperties: {},
+          designProperties: {},
+          slots: {}
+        },
+        {
+          id: 'fragNode1',
+          nodeType: 'ExperienceFragment',
+          experienceFragment: resourceLink('Contentful:ExperienceFragment', fragmentUrn(publishedFragmentA.sys.id))
+        }
+      ],
+      metadata: { tags: [], concepts: [] }
+    }
+  )
+  const publishedCompositeComponent = await client.component.publish({ componentId: compositeComponent.sys.id, version: compositeComponent.sys.version })
+  createdIds.components.push(publishedBaseComponent.sys.id, publishedLeafComponent.sys.id, publishedCompositeComponent.sys.id)
+
+  // Experience Fragments (2) -- fragmentA (above) and fragmentB, which wraps the composite
+  // component and binds contentBindings to a DataAssembly + a real Entry.
+  const fragmentB = await client.experienceFragment.create(
+    {},
+    {
+      name: 'Fragment B',
+      description: 'Fragment wrapping the composite component with contentBindings',
+      viewports: [VIEWPORT],
+      designProperties: {},
+      component: resourceLink('Contentful:Component', componentUrn(publishedCompositeComponent.sys.id)),
+      contentBindings: {
+        sys: resourceLink('Contentful:DataAssembly', dataAssemblyUrn(publishedAssemblyB.sys.id)).sys,
+        parameters: { p_entry: resourceLink('Contentful:Entry', entryUrn(publishedEntry.sys.id)) }
+      }
+    }
+  )
+  const publishedFragmentB = await client.experienceFragment.publish({ experienceFragmentId: fragmentB.sys.id, version: fragmentB.sys.version })
+  createdIds.experienceFragments.push(publishedFragmentA.sys.id, publishedFragmentB.sys.id)
+
+  // Experience Templates (2) -- templateA wraps fragmentA; templateB exercises a Component
+  // tree node + an ExperienceFragment tree node together, plus a DataAssembly link.
+  const templateA = await client.experienceTemplate.create(
+    {},
+    {
+      name: 'Template A',
+      description: 'Template wrapping fragment A',
+      viewports: [VIEWPORT],
+      contentProperties: [],
+      designProperties: [],
+      dataAssemblies: [resourceLink('Contentful:DataAssembly', dataAssemblyUrn(publishedAssemblyA.sys.id))],
+      componentTree: [
+        {
+          id: 'tplFragNode1',
+          nodeType: 'ExperienceFragment',
+          experienceFragment: resourceLink('Contentful:ExperienceFragment', fragmentUrn(publishedFragmentA.sys.id))
+        }
+      ],
+      metadata: { tags: [], concepts: [] }
+    }
+  )
+  const publishedTemplateA = await client.experienceTemplate.publish({ experienceTemplateId: templateA.sys.id, version: templateA.sys.version })
+
+  const templateB = await client.experienceTemplate.create(
+    {},
+    {
+      name: 'Template B',
+      description: 'Template wrapping the composite component and fragment B',
+      viewports: [VIEWPORT],
+      contentProperties: [],
+      designProperties: [],
+      dataAssemblies: [resourceLink('Contentful:DataAssembly', dataAssemblyUrn(publishedAssemblyB.sys.id))],
+      componentTree: [
+        {
+          id: 'tplCompNode1',
+          nodeType: 'Component',
+          component: resourceLink('Contentful:Component', componentUrn(publishedCompositeComponent.sys.id)),
+          contentProperties: {},
+          designProperties: {},
+          slots: {}
+        },
+        {
+          id: 'tplFragNode2',
+          nodeType: 'ExperienceFragment',
+          experienceFragment: resourceLink('Contentful:ExperienceFragment', fragmentUrn(publishedFragmentB.sys.id))
+        }
+      ],
+      metadata: { tags: [], concepts: [] }
+    }
+  )
+  const publishedTemplateB = await client.experienceTemplate.publish({ experienceTemplateId: templateB.sys.id, version: templateB.sys.version })
+  createdIds.experienceTemplates.push(publishedTemplateA.sys.id, publishedTemplateB.sys.id)
+
+  // Experiences (2) -- one per template.
+  const experienceA = await client.experience.create(
+    {},
+    {
+      name: 'Experience A',
+      description: 'Experience built from template A',
+      viewports: [VIEWPORT],
+      designProperties: {},
+      experienceTemplate: resourceLink('Contentful:ExperienceTemplate', `${EXO_URN_BASE}/experienceTemplates/${publishedTemplateA.sys.id}`)
+    }
+  )
+  const publishedExperienceA = await client.experience.publish({ experienceId: experienceA.sys.id, version: experienceA.sys.version })
+
+  const experienceB = await client.experience.create(
+    {},
+    {
+      name: 'Experience B',
+      description: 'Experience built from template B',
+      viewports: [VIEWPORT],
+      designProperties: {},
+      experienceTemplate: resourceLink('Contentful:ExperienceTemplate', `${EXO_URN_BASE}/experienceTemplates/${publishedTemplateB.sys.id}`)
+    }
+  )
+  const publishedExperienceB = await client.experience.publish({ experienceId: experienceB.sys.id, version: experienceB.sys.version })
+  createdIds.experiences.push(publishedExperienceA.sys.id, publishedExperienceB.sys.id)
+})
+
+afterAll(async () => {
+  await rootClient.space.delete({ spaceId })
+  rimraf.sync(tmpFolder)
+})
+
+describe('Experience Orchestration', () => {
+  it('exports all 6 ExO arrays with exactly the entities and relationships that were seeded', () => {
+    return runContentfulExport({
+      spaceId,
+      managementToken,
+      saveFile: false,
+      exportDir: tmpFolder,
+      includeExperienceOrchestration: true
+    }).then((content) => {
+      Object.keys(createdIds).forEach((field) => {
+        expect(Array.isArray(content[field])).toBe(true)
+        expect(content[field]).toHaveLength(createdIds[field].length)
+        const exportedIds = content[field].map((item) => item.sys.id)
+        expect(new Set(exportedIds)).toEqual(new Set(createdIds[field]))
+      })
+
+      const exportedCompositeComponent = content.components.find((c) => c.name === 'Composite Component')
+      const treeNodeTypes = exportedCompositeComponent.componentTree.map((node) => node.nodeType)
+      expect(treeNodeTypes).toEqual(expect.arrayContaining(['Component', 'ExperienceFragment']))
+
+      const exportedFragmentB = content.experienceFragments.find((f) => f.name === 'Fragment B')
+      expect(exportedFragmentB.contentBindings.sys.urn).toBe(dataAssemblyUrn(createdIds.dataAssemblies[1]))
+      expect(exportedFragmentB.contentBindings.parameters.p_entry.sys.urn).toBe(entryUrn(entryId))
+    })
+  })
+})


### PR DESCRIPTION
## Summary
Add a basic integration test to export data from a real Contentful Org/Space and make assertions that Experience Orchestration data is exported correctly.

This PR leverages the existing integration test setup, [export-lib.test.js](https://github.com/contentful/contentful-export/blob/exo/test/integration/export-lib.test.js), so no new env vars are required, nor is this a breaking change for CI or users.

## PR Checklist

- [ ] I have read the `CONTRIBUTING.md` file
- [ ] All commits follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Documentation is updated (if necessary)
- [ ] PR doesn't contain any sensitive information
- [ ] There are no breaking changes
