### PR TITLE
feat: default includeExperienceOrchestration to true and document ExO export support [AIS-137]

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,9 +270,9 @@ Display progress in new lines instead of displaying a busy spinner and the statu
 
 ### Experience Orchestration
 
-#### `includeExperienceOrchestration` [boolean] [default: `true` when run via the CLI — the most common way this tool is used; `false` if you call the module API directly without setting it — see below]
+#### `includeExperienceOrchestration` [boolean] [default: true]
 
-Flag controlling whether Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Data Assemblies, Experience Fragments, and Experiences — are exported when present in the source space. Requires the `exoM1` entitlement on the source space's organization. See the "Experience Orchestration (ExO) entities" section below for the CLI-vs-module default split and what happens when the space isn't entitled.
+Flag controlling whether Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Data Assemblies, Experience Fragments, and Experiences — are exported when present in the source space. Requires the `exoM1` entitlement on the source space's organization. Set to `false` to opt out. See the "Experience Orchestration (ExO) entities" section below for what happens when the space isn't entitled.
 
 ## :rescue_worker_helmet: Troubleshooting
 
@@ -342,16 +342,13 @@ This is an overview of the exported data:
 
 _Note:_ Tags feature is not available for all users. If you do not have access to this feature, the tags array will always be empty.
 
-_Note:_ `designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, and `experiences` are Experience Orchestration (ExO) entities, only present when `includeExperienceOrchestration` is set — see the "Experience Orchestration (ExO) entities" section below.
+_Note:_ `designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, and `experiences` are Experience Orchestration (ExO) entities — present by default; absent only if you explicitly set `includeExperienceOrchestration: false` — see the "Experience Orchestration (ExO) entities" section below.
 
 ## :test_tube: Experience Orchestration (ExO) entities
 
 > **Experimental:** ExO entities (`designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, `experiences`) are `@internal` and considered experimental. Their shape and export behavior are subject to change without notice.
 
-ExO export behavior depends on how you run this tool — the default is not the same in both places:
-
-- **CLI** (`bin/contentful-export` — the executable `npm install -g contentful-export` / `npx contentful-export` runs, and the most common way this tool gets used): `--include-experience-orchestration` defaults to `true`. ExO entities export automatically with no flags passed; pass `--include-experience-orchestration=false` to opt out.
-- **Module API** (`require('contentful-export')(options)`): `includeExperienceOrchestration` defaults to `false`. You must explicitly set it to `true` to get ExO entities.
+ExO export is on by default (`includeExperienceOrchestration: true`) — for the CLI and the module API alike. Pass `includeExperienceOrchestration: false` (`--include-experience-orchestration=false` on the CLI) to opt out.
 
 ```javascript
 const contentfulExport = require('contentful-export')
@@ -359,13 +356,15 @@ const contentfulExport = require('contentful-export')
 const options = {
   spaceId: '<space_id>',
   managementToken: '<content_management_api_key>',
-  includeExperienceOrchestration: true // required here — the module API defaults to false, unlike the CLI
+  includeExperienceOrchestration: false // opt out; omit to export ExO entities when present (the default)
 }
 
 contentfulExport(options)
 ```
 
-Both paths require the `exoM1` entitlement on the source space's organization. Separately, [contentful-cli](https://github.com/contentful/contentful-cli)'s `space export` command doesn't expose this option at all yet, so ExO export isn't reachable through that CLI regardless of default.
+Unlike `contentful-import` (where this default is a complete no-op for source content with no ExO entities — the import-side entitlement check only runs if the source data actually has ExO entities to import), `contentful-export`'s six ExO fetch tasks in `lib/tasks/get-space-data.js` are gated only on `includeExperienceOrchestration`, not on whether the source space actually has any ExO content. That means every export now always attempts all six ExO endpoint calls. Against a non-entitled or ExO-empty space, each one fails or returns empty, gets caught, and logs a `Skipping <Entity> export` warning — six new warning lines and six extra network round-trips on every run, even for spaces with nothing to do with ExO. The export still succeeds either way (see below) — this is a cost/noise note, not a correctness one. Pass `includeExperienceOrchestration: false` if you want to avoid it.
+
+Requires the `exoM1` entitlement on the source space's organization. [contentful-cli](https://github.com/contentful/contentful-cli)'s `space export` command doesn't expose this option at all yet, so ExO export isn't reachable through that separate CLI regardless of default.
 
 If the source space isn't entitled — or any single ExO entity type fails to fetch for any other reason — that entity type is logged as a **warning** and exported as an empty array; it does not fail the export. Unlike `contentful-import` (where the equivalent missing-entitlement case is logged at `error` level and causes the overall promise to reject even though the rest of the content imported), `contentful-export`'s `contentfulExport()` call still resolves successfully in this case. Check the console output or `errorLogFile` for `Skipping <Entity> export` if you expect ExO content but don't see it in the result.
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ Full path to the error log file
 
 Display progress in new lines instead of displaying a busy spinner and the status in the same line. Useful for CI.
 
+### Experience Orchestration
+
+#### `includeExperienceOrchestration` [boolean] [default: false]
+
+Opt-in flag to export Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Data Assemblies, Experience Fragments, and Experiences — if present in the source space. Requires the `exoM1` entitlement on the source space's organization. See the "Experience Orchestration (ExO) entities" section below for what happens when the space isn't entitled.
+
 ## :rescue_worker_helmet: Troubleshooting
 
 ### Proxy
@@ -324,11 +330,39 @@ This is an overview of the exported data:
   "tags": [],
   "webhooks": [],
   "roles": [],
-  "editorInterfaces": []
+  "editorInterfaces": [],
+  "designTokens": [],
+  "components": [],
+  "experienceTemplates": [],
+  "dataAssemblies": [],
+  "experienceFragments": [],
+  "experiences": []
 }
 ```
 
 _Note:_ Tags feature is not available for all users. If you do not have access to this feature, the tags array will always be empty.
+
+_Note:_ `designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, and `experiences` are Experience Orchestration (ExO) entities, only present when `includeExperienceOrchestration` is set — see the "Experience Orchestration (ExO) entities" section below.
+
+## :test_tube: Experience Orchestration (ExO) entities
+
+> **Experimental:** ExO entities (`designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, `experiences`) are `@internal` and considered experimental. Their shape and export behavior are subject to change without notice.
+
+ExO export is opt-in via the `includeExperienceOrchestration` option (see "Configuration options" above) and requires the `exoM1` entitlement on the source space's organization.
+
+```javascript
+const contentfulExport = require('contentful-export')
+
+const options = {
+  spaceId: '<space_id>',
+  managementToken: '<content_management_api_key>',
+  includeExperienceOrchestration: true
+}
+
+contentfulExport(options)
+```
+
+If the source space isn't entitled — or any single ExO entity type fails to fetch for any other reason — that entity type is logged as a **warning** and exported as an empty array; it does not fail the export. Unlike `contentful-import` (where the equivalent missing-entitlement case is logged at `error` level and causes the overall promise to reject even though the rest of the content imported), `contentful-export`'s `contentfulExport()` call still resolves successfully in this case. Check the console output or `errorLogFile` for `Skipping <Entity> export` if you expect ExO content but don't see it in the result.
 
 ## :warning: Limitations
 

--- a/README.md
+++ b/README.md
@@ -346,6 +346,8 @@ _Note:_ `designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `
 
 ## :test_tube: Experience Orchestration (ExO) entities
 
+Experience Orchestration (ExO) is Contentful's system for composing and rendering structured page experiences. It sits above the traditional entry/content-type layer and provides six dedicated entity types — Design Tokens, Components, Experience Templates, Data Assemblies, Experience Fragments, and Experiences — that together describe how content is fetched, assembled, and laid out.
+
 > **Experimental:** ExO entities (`designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, `experiences`) are `@internal` and considered experimental. Their shape and export behavior are subject to change without notice.
 
 ExO export is on by default (`includeExperienceOrchestration: true`) — for the CLI and the module API alike. Pass `includeExperienceOrchestration: false` (`--include-experience-orchestration=false` on the CLI) to opt out.
@@ -365,6 +367,10 @@ contentfulExport(options)
 If the source space has no ExO entities, or lacks the `exoM1` entitlement, each ExO entity type logs a `Skipping <Entity> export` warning and exports as an empty array — it does not fail the export. Pass `includeExperienceOrchestration: false` if you want to avoid it.
 
 Requires the `exoM1` entitlement on the source space's organization. [contentful-cli](https://github.com/contentful/contentful-cli)'s `space export` command doesn't expose this option at all yet, so ExO export isn't reachable through that separate CLI regardless of default.
+
+### Round-tripping into `contentful-import`
+
+The ExO entities exported here are designed to be fed directly into [`contentful-import`](https://github.com/contentful/contentful-import), which preserves source IDs, applies dependency ordering (a topological sort for Components and Experience Fragments, since either can reference others of the same type), and upgrades entities from older, pre-rename export files automatically. See `contentful-import`'s README "Experience Orchestration (ExO) entities" section for the import-side details.
 
 ## :warning: Limitations
 

--- a/README.md
+++ b/README.md
@@ -270,9 +270,9 @@ Display progress in new lines instead of displaying a busy spinner and the statu
 
 ### Experience Orchestration
 
-#### `includeExperienceOrchestration` [boolean] [default: false]
+#### `includeExperienceOrchestration` [boolean] [default: false via the module API; `true` via the bundled CLI — see below]
 
-Opt-in flag to export Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Data Assemblies, Experience Fragments, and Experiences — if present in the source space. Requires the `exoM1` entitlement on the source space's organization. See the "Experience Orchestration (ExO) entities" section below for what happens when the space isn't entitled.
+Opt-in flag to export Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Data Assemblies, Experience Fragments, and Experiences — if present in the source space. Requires the `exoM1` entitlement on the source space's organization. See the "Experience Orchestration (ExO) entities" section below for the CLI-vs-module default asymmetry and what happens when the space isn't entitled.
 
 ## :rescue_worker_helmet: Troubleshooting
 
@@ -361,6 +361,8 @@ const options = {
 
 contentfulExport(options)
 ```
+
+> **CLI users, note the flipped default:** the module API defaults `includeExperienceOrchestration` to `false` (opt-in), as shown above. The bundled `contentful-export` executable (`bin/contentful-export`, the same binary `npm install -g contentful-export` / `npx contentful-export` runs) defaults `--include-experience-orchestration` to `true` (opt-out) — so running the CLI with no flags exports ExO entities by default, while calling the module with no options does not. Pass `--include-experience-orchestration=false` to the CLI if you don't want ExO content. Separately, [contentful-cli](https://github.com/contentful/contentful-cli)'s `space export` command doesn't expose this option at all yet, so ExO export isn't reachable through that CLI regardless of default.
 
 If the source space isn't entitled — or any single ExO entity type fails to fetch for any other reason — that entity type is logged as a **warning** and exported as an empty array; it does not fail the export. Unlike `contentful-import` (where the equivalent missing-entitlement case is logged at `error` level and causes the overall promise to reject even though the rest of the content imported), `contentful-export`'s `contentfulExport()` call still resolves successfully in this case. Check the console output or `errorLogFile` for `Skipping <Entity> export` if you expect ExO content but don't see it in the result.
 

--- a/README.md
+++ b/README.md
@@ -362,11 +362,9 @@ const options = {
 contentfulExport(options)
 ```
 
-Unlike `contentful-import` (where this default is a complete no-op for source content with no ExO entities — the import-side entitlement check only runs if the source data actually has ExO entities to import), `contentful-export`'s six ExO fetch tasks in `lib/tasks/get-space-data.js` are gated only on `includeExperienceOrchestration`, not on whether the source space actually has any ExO content. That means every export now always attempts all six ExO endpoint calls. Against a non-entitled or ExO-empty space, each one fails or returns empty, gets caught, and logs a `Skipping <Entity> export` warning — six new warning lines and six extra network round-trips on every run, even for spaces with nothing to do with ExO. The export still succeeds either way (see below) — this is a cost/noise note, not a correctness one. Pass `includeExperienceOrchestration: false` if you want to avoid it.
+If the source space has no ExO entities, or lacks the `exoM1` entitlement, each ExO entity type logs a `Skipping <Entity> export` warning and exports as an empty array — it does not fail the export. Pass `includeExperienceOrchestration: false` if you want to avoid it.
 
 Requires the `exoM1` entitlement on the source space's organization. [contentful-cli](https://github.com/contentful/contentful-cli)'s `space export` command doesn't expose this option at all yet, so ExO export isn't reachable through that separate CLI regardless of default.
-
-If the source space isn't entitled — or any single ExO entity type fails to fetch for any other reason — that entity type is logged as a **warning** and exported as an empty array; it does not fail the export. Unlike `contentful-import` (where the equivalent missing-entitlement case is logged at `error` level and causes the overall promise to reject even though the rest of the content imported), `contentful-export`'s `contentfulExport()` call still resolves successfully in this case. Check the console output or `errorLogFile` for `Skipping <Entity> export` if you expect ExO content but don't see it in the result.
 
 ## :warning: Limitations
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Experience Orchestration (ExO) is Contentful's system for composing and renderin
 ExO export is on by default (`includeExperienceOrchestration: true`) — for the CLI and the module API alike. Pass `includeExperienceOrchestration: false` (`--include-experience-orchestration=false` on the CLI) to opt out.
 
 ```javascript
-const contentfulExport = require('contentful-export')
+import contentfulExport from 'contentful-export'
 
 const options = {
   spaceId: '<space_id>',
@@ -361,7 +361,7 @@ const options = {
   includeExperienceOrchestration: false // opt out; omit to export ExO entities when present (the default)
 }
 
-contentfulExport(options)
+await contentfulExport(options)
 ```
 
 If the source space has no ExO entities, or lacks the `exoM1` entitlement, each ExO entity type logs a `Skipping <Entity> export` warning and exports as an empty array — it does not fail the export. Pass `includeExperienceOrchestration: false` if you want to avoid it.

--- a/README.md
+++ b/README.md
@@ -270,9 +270,9 @@ Display progress in new lines instead of displaying a busy spinner and the statu
 
 ### Experience Orchestration
 
-#### `includeExperienceOrchestration` [boolean] [default: false via the module API; `true` via the bundled CLI — see below]
+#### `includeExperienceOrchestration` [boolean] [default: `true` when run via the CLI — the most common way this tool is used; `false` if you call the module API directly without setting it — see below]
 
-Opt-in flag to export Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Data Assemblies, Experience Fragments, and Experiences — if present in the source space. Requires the `exoM1` entitlement on the source space's organization. See the "Experience Orchestration (ExO) entities" section below for the CLI-vs-module default asymmetry and what happens when the space isn't entitled.
+Flag controlling whether Experience Orchestration (ExO) entities — Design Tokens, Components, Experience Templates, Data Assemblies, Experience Fragments, and Experiences — are exported when present in the source space. Requires the `exoM1` entitlement on the source space's organization. See the "Experience Orchestration (ExO) entities" section below for the CLI-vs-module default split and what happens when the space isn't entitled.
 
 ## :rescue_worker_helmet: Troubleshooting
 
@@ -348,7 +348,10 @@ _Note:_ `designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `
 
 > **Experimental:** ExO entities (`designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, `experiences`) are `@internal` and considered experimental. Their shape and export behavior are subject to change without notice.
 
-ExO export is opt-in via the `includeExperienceOrchestration` option (see "Configuration options" above) and requires the `exoM1` entitlement on the source space's organization.
+ExO export behavior depends on how you run this tool — the default is not the same in both places:
+
+- **CLI** (`bin/contentful-export` — the executable `npm install -g contentful-export` / `npx contentful-export` runs, and the most common way this tool gets used): `--include-experience-orchestration` defaults to `true`. ExO entities export automatically with no flags passed; pass `--include-experience-orchestration=false` to opt out.
+- **Module API** (`require('contentful-export')(options)`): `includeExperienceOrchestration` defaults to `false`. You must explicitly set it to `true` to get ExO entities.
 
 ```javascript
 const contentfulExport = require('contentful-export')
@@ -356,13 +359,13 @@ const contentfulExport = require('contentful-export')
 const options = {
   spaceId: '<space_id>',
   managementToken: '<content_management_api_key>',
-  includeExperienceOrchestration: true
+  includeExperienceOrchestration: true // required here — the module API defaults to false, unlike the CLI
 }
 
 contentfulExport(options)
 ```
 
-> **CLI users, note the flipped default:** the module API defaults `includeExperienceOrchestration` to `false` (opt-in), as shown above. The bundled `contentful-export` executable (`bin/contentful-export`, the same binary `npm install -g contentful-export` / `npx contentful-export` runs) defaults `--include-experience-orchestration` to `true` (opt-out) — so running the CLI with no flags exports ExO entities by default, while calling the module with no options does not. Pass `--include-experience-orchestration=false` to the CLI if you don't want ExO content. Separately, [contentful-cli](https://github.com/contentful/contentful-cli)'s `space export` command doesn't expose this option at all yet, so ExO export isn't reachable through that CLI regardless of default.
+Both paths require the `exoM1` entitlement on the source space's organization. Separately, [contentful-cli](https://github.com/contentful/contentful-cli)'s `space export` command doesn't expose this option at all yet, so ExO export isn't reachable through that CLI regardless of default.
 
 If the source space isn't entitled — or any single ExO entity type fails to fetch for any other reason — that entity type is logged as a **warning** and exported as an empty array; it does not fail the export. Unlike `contentful-import` (where the equivalent missing-entitlement case is logged at `error` level and causes the overall promise to reject even though the rest of the content imported), `contentful-export`'s `contentfulExport()` call still resolves successfully in this case. Check the console output or `errorLogFile` for `Skipping <Entity> export` if you expect ExO content but don't see it in the result.
 

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -20,7 +20,7 @@ export default function parseOptions (params) {
     skipTags: false,
     stripTags: false,
     maxAllowedLimit: 1000,
-    includeExperienceOrchestration: false,
+    includeExperienceOrchestration: true,
     saveFile: true,
     useVerboseRenderer: false,
     rawProxy: false


### PR DESCRIPTION
[AIS-137](https://contentful.atlassian.net/browse/AIS-137)

## Summary
- **Behavior change**: default `includeExperienceOrchestration` to `true` in `lib/parseOptions.js` (the module API), matching the CLI's existing default (set in `lib/usageParams.js` under AIS-96 / #2342) so there's one consistent default instead of a confusing CLI-vs-module split
  - Unlike `contentful-import`, this isn't a no-op for non-ExO users: the six ExO fetch tasks in `get-space-data.js` are gated only on `includeExperienceOrchestration`, not on whether the source space has any ExO content — so every export now attempts all six ExO endpoint calls. Against a non-entitled space each one warns and returns empty; the export still succeeds, just with extra calls and log noise
  - Verified: 48/48 unit tests still pass (one pre-existing, unrelated `nock`/`undici` environment failure confirmed present before this change too)
- Add `includeExperienceOrchestration` to the Configuration options section, now describing the single unified default
- Add the ExO entity keys to the "Exported data structure" JSON example, noting they're present by default
- Document the `exoM1` entitlement requirement on the source space, and the actual behavior on a fetch failure (logged as a warning, entity type exported as `[]`, export still resolves successfully — the opposite of `contentful-import`'s equivalent case)
- Add the `@internal`/experimental disclaimer for ExO entities

## Test plan
- [x] Ran `npx jest test/unit` after the default flip — 48/48 tests pass, no regressions (pre-existing unrelated failure in `download-assets.test.js` confirmed present on the unmodified branch too)
- [ ] Rendered README locally to confirm markdown formatting

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-137]: https://contentful.atlassian.net/browse/AIS-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ