### PR TITLE
fix: remove yieldRate from bfj.write to unblock large space exports [DX-1343]

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -134,8 +134,11 @@ export default function runContentfulExport (params) {
                 return bfj.write(options.logFilePath, ctx.data, {
                   circular: 'ignore',
                   space: 2,
-                  bufferLength: 1024,
-                  yieldRate: 16384
+                  // Do not set `yieldRate` -- values above `bufferLength`
+                  // make bfj 9's serialization quadratic and it never
+                  // finishes. See DX-1343.
+                  bufferLength: 65536,
+                  highWaterMark: 1024 * 1024
                 })
               }
             }


### PR DESCRIPTION
[DX-1343](https://contentful.atlassian.net/browse/DX-1343)

## Summary

- **Removes `yieldRate: 16384` from the `bfj.write()` call in `lib/index.js`.** This parameter was added in 8.1.1 (for [DX-1002](https://contentful.atlassian.net/browse/DX-1002)) to restore what were believed to be bfj 8's defaults. On bfj 9 it makes serialization quadratic, so the `Writing data to file` step never completes on a large space. `yieldRate` is the sole cause — `bufferLength: 1024` is harmless.
- **Raises `bufferLength` to 65536 and adds `highWaterMark: 1 MB`** rather than reverting to 8.1.0's parameters. Measured 24% faster than 8.1.0 at multi-GB scale.
- **Why it hangs:** bfj 9 emits serialization events without awaiting their handlers, so `yieldRate` is the only backpressure on the producer. At 16384 the Hoopy buffer fills long before the yield counter trips, and `emitter.pause()`'s unpause resets that counter, so `eventify` never reaches its own `setImmediate` yield. bfj 9's unbounded event queue then dequeues via an O(n) `Array.shift()`. Instrumenting `eventQueue.length` on a 1,500-entry fixture shows a peak queue depth of **0** at the default yieldRate versus **369,562** pending promises at 16384.
- **DX-1002's premise was also wrong:** bfj 8 and bfj 9 perform comparably at their own defaults, so there was never a bfj-major regression to restore behaviour from. bfj 8's constants are only safe on bfj 8's O(1) chained mutex.

## Verified at the reporting customer's scale (~10 GB)

[ES-616](https://contentful.atlassian.net/browse/ES-616) reports a ~10 GB space. Reproduced with an export-shaped fixture on Node 22 / 32 GB macOS, writing real files to disk and deleting them after each run. All figures pretty-printed output with `space: 2`:

| Output written | 8.1.1 – 8.2.0 (shipped) | 8.1.0 (bfj 9 defaults) | **This PR** |
| --- | --- | --- | --- |
| 11.5 MB | timeout >60s | 1.61s | **1.00s** |
| 1.16 GB | **3.8 MB in 180s, aborted** | — | **251.8s** |
| 3.50 GB | — | 675.5s | **510.4s** |
| **10.09 GB** | — | — | **2944.9s (49 min)** |

The headline result: **a 10.09 GB export completes in 49 minutes on this branch.** Under the shipped options the same write produced 3.8 MB in 180 seconds — an extrapolated ~15 years for 10 GB. That is why it presents as an indefinite hang with no error and no exit: it is making real but asymptotically useless progress, and at small sizes it merely looks slow, which is how it passed review.

Throughput holds in a 3.4–6.9 MB/s band from 1 GB to 10 GB, i.e. the write is now linear-bounded work. The 10 GB rung came in at the low end (3.4 MB/s) because 8.5 GB of live heap on a 32 GB laptop causes paging; on a host with real headroom expect nearer 6 MB/s.

Peak RSS was 4.58 GB against a ~3 GB object graph, so the larger ring buffer costs a few MB — not material next to `ctx.data` itself.

**Affected versions:** 8.1.1, 8.1.2, 8.1.3, 8.2.0 (current `latest`) and 9.0.0 (`exo`), for anyone with `saveFile: true` — the default. `contentful-cli` is **not** affected: it pins `contentful-export: ^7.22.4`, the lock resolves 7.22.4, and 7.x never received the change.

## What this does not fix

49 minutes for a 10 GB backup is a restoration of correctness, not good performance. Two follow-ups are tracked on DX-1343:

- **Replace bfj.** A native streaming-writer prototype measured 130 MB/s on the same fixture, which would put this export near 77 seconds instead of 49 minutes. bfj is effectively unmaintained and its `tryer` polling loop has no timeout or retry limit, so its only failure mode is hanging.
- **Peak memory is untouched.** `ctx.data` materializes the whole space as live JS objects before serialization starts — 8.5 GB of heap for this 10 GB export. `saveFile: false` does not avoid that, it only skips the write, so the customer's memory complaint needs a genuinely streaming export and is out of scope here.

## Test plan

- [x] `npx eslint lib/index.js` passes
- [x] `npx jest test/unit` — 55 tests across 7 suites pass
- [x] **10.09 GB written successfully in 2944.9s** at the customer's reported scale
- [x] Shipped options confirmed non-viable at scale: 3.8 MB in 180s at the 1.16 GB rung
- [x] Beats 8.1.0 defaults back-to-back at 3.50 GB: 510.4s vs 675.5s
- [x] Serialized output verified `deepStrictEqual` to the source data — no fidelity change
- [ ] Reviewer sanity check against a real large space rather than a synthetic fixture

## Open question

- No regression test is included. `test/unit/index.test.js:28` mocks bfj wholesale (`jest.mock('bfj', () => ({ write: jest.fn().mockResolvedValue() }))`), which is why nothing caught this. A meaningful test needs a fixture large enough to expose quadratic behaviour, which is too slow for the unit suite — so it likely belongs in the integration suite with a wall-clock budget. Tracked on DX-1343; happy to add it here instead if reviewers prefer it blocking.

Generated with [Claude Code](https://claude.com/claude-code)

[DX-1343]: https://contentful.atlassian.net/browse/DX-1343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DX-1002]: https://contentful.atlassian.net/browse/DX-1002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ES-616]: https://contentful.atlassian.net/browse/ES-616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ