### PR TITLE
feat: export Optimization Variants nested on their parent Experience/Fragment [AIS-139]

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,23 @@ If the source space has no ExO entities, or lacks the `exoM1` entitlement, each 
 
 Requires the `exoM1` entitlement on the source space's organization. [contentful-cli](https://github.com/contentful/contentful-cli)'s `space export` command doesn't expose this option at all yet, so ExO export isn't reachable through that separate CLI regardless of default.
 
+### Optimization Variants
+
+Experiences and Experience Fragments each support **Optimization Variants** — alternate versions used for personalization. Variants are a separate opt-in on top of `includeExperienceOrchestration`, defaulting to `false`:
+
+```javascript
+const options = {
+  spaceId: '<space_id>',
+  managementToken: '<content_management_api_key>',
+  includeExperienceOrchestration: true,
+  includeExoVariants: true
+}
+
+await contentfulExport(options)
+```
+
+Unlike the six entity types above, variants are **not** exported as a seventh top-level array — they're nested onto their parent as `experience.optimizationVariants` / `experienceFragment.optimizationVariants`, because a variant has no globally-unique `sys.id` of its own (the API's variant response reuses the parent's `sys.id`; the variant is identified by `sys.variant`/`sys.variantType`/`sys.variantDimension` instead). When `includeExoVariants` is omitted or `false`, the `optimizationVariants` field is absent entirely — not an empty array — so default export output is unaffected. See [`docs/exo-export.md`](./docs/exo-export.md#optimization-variants) for the full shape, the ADR behind the nested-storage decision, and the corresponding `contentful-import` behavior.
+
 ### Round-tripping into `contentful-import`
 
 The ExO entities exported here are designed to be fed directly into [`contentful-import`](https://github.com/contentful/contentful-import), which preserves source IDs, applies dependency ordering (a topological sort for Components and Experience Fragments, since either can reference others of the same type), and upgrades entities from older, pre-rename export files automatically. See `contentful-import`'s README "Experience Orchestration (ExO) entities" section for the import-side details.

--- a/docs/exo-export.md
+++ b/docs/exo-export.md
@@ -62,3 +62,57 @@ The six ExO fields are appended to the standard export output:
 ## Using ExO export output with contentful-import
 
 The six ExO arrays exported here are designed to be fed directly into `contentful-import` with `includeExperienceOrchestration: true`. Import handles ID preservation, dependency ordering (topological sort for Components and Fragments), and folder concept rewriting. See [contentful-import's ExO doc](https://github.com/contentful/contentful-import/blob/main/docs/exo-import.md) for import-side details.
+
+## Optimization Variants
+
+Experiences and Experience Fragments each support **Optimization Variants** — alternate versions of the same entity used for personalization. Unlike every other ExO entity type, a variant has no globally-unique `sys.id` of its own: the API's optimization-variants response reuses the **parent's** `sys.id`, and identifies the variant instead via `sys.variant` (a server-generated UUID), `sys.variantType`, and `sys.variantDimension`.
+
+Because of that non-unique ID, variants are **not** exported as a seventh flat top-level array the way the other six ExO entity types are. Exporting them that way would silently collide entries under the same `sys.id` the moment more than one variant existed per parent. Instead, variants are nested directly onto their parent:
+
+```json
+{
+  "experiences": [
+    {
+      "sys": { "id": "abc123", "type": "Experience", "variant": "default", "variantType": "default" },
+      "name": "Homepage",
+      "optimizationVariants": [
+        {
+          "sys": { "id": "abc123", "type": "Experience", "variant": "f3a1...", "variantType": "personalization" },
+          "name": "Homepage (Variant A)"
+        }
+      ]
+    }
+  ],
+  "experienceFragments": [
+    {
+      "sys": { "id": "def456", "type": "ExperienceFragment" },
+      "name": "Hero Banner",
+      "optimizationVariants": []
+    }
+  ]
+}
+```
+
+This is additive: no existing helper that builds or reads the six top-level arrays needed to change, since variants live in a new nested field rather than a seventh flat array that would need the same `sys.id`-uniqueness assumption the other six rely on.
+
+### Enabling variant export
+
+Variant export is a separate opt-in on top of `includeExperienceOrchestration`, defaulting to `false`:
+
+```javascript
+const result = await contentfulExport({
+  spaceId: '<space_id>',
+  managementToken: '<management_token>',
+  includeExperienceOrchestration: true,
+  includeExoVariants: true,
+})
+```
+
+- When `includeExoVariants` is **omitted or `false`**, `experience`/`experienceFragment` objects have no `optimizationVariants` field at all — not even an empty array. This keeps the default export output byte-identical to before this feature existed.
+- When **`true`**, every Experience and Experience Fragment gets an `optimizationVariants` array, even if empty (a parent with no real variants exports `optimizationVariants: []`, not an absent field).
+- The upstream API's `optimization_variants` list endpoint always leads with an entry representing the parent's own base view (`sys.variantType: 'default'`) — that's the same entity already exported as its own top-level Experience/ExperienceFragment, not a real variant, so it's filtered out here to avoid double-counting.
+- Each type's count also appears as its own row in the CLI summary table (`Experience Optimization Variants` / `Experience Fragment Optimization Variants`) when the flag is enabled.
+
+### Using variant export output with contentful-import
+
+`contentful-import`'s ExO import handles the nested `optimizationVariants` array automatically when `includeExperienceOrchestration: true` is passed — no separate import-side flag is needed; import behavior is driven by whether the field is present in the source data. See [contentful-import's ExO doc](https://github.com/contentful/contentful-import/blob/main/docs/exo-import.md#optimization-variants) for import-side details, including why variant IDs are not preserved across import (the upstream API always server-generates a fresh ID on create).

--- a/lib/index.js
+++ b/lib/index.js
@@ -90,6 +90,7 @@ export default function runContentfulExport (params) {
             skipTags: options.skipTags,
             stripTags: options.stripTags,
             includeExperienceOrchestration: options.includeExperienceOrchestration,
+            includeExoVariants: options.includeExoVariants,
             listrOptions,
             queryEntries: options.queryEntries,
             queryAssets: options.queryAssets
@@ -162,6 +163,19 @@ export default function runContentfulExport (params) {
         resultTypes.forEach((type) => {
           resultTable.push([startCase(type), ctx.data[type].length])
         })
+
+        // Optimization Variants are nested onto their parent Experience/Experience
+        // Fragment rather than exported as their own top-level field (see
+        // projects/decisions/0001-exo-variant-export-storage-shape.md), so their count
+        // isn't free from resultTypes above and is computed here instead.
+        if (ctx.data.experiences?.some((experience) => experience.optimizationVariants)) {
+          const count = ctx.data.experiences.reduce((sum, experience) => sum + (experience.optimizationVariants?.length ?? 0), 0)
+          resultTable.push(['Experience Optimization Variants', count])
+        }
+        if (ctx.data.experienceFragments?.some((experienceFragment) => experienceFragment.optimizationVariants)) {
+          const count = ctx.data.experienceFragments.reduce((sum, experienceFragment) => sum + (experienceFragment.optimizationVariants?.length ?? 0), 0)
+          resultTable.push(['Experience Fragment Optimization Variants', count])
+        }
 
         console.log(resultTable.toString())
       } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -165,8 +165,7 @@ export default function runContentfulExport (params) {
         })
 
         // Optimization Variants are nested onto their parent Experience/Experience
-        // Fragment rather than exported as their own top-level field (see
-        // projects/decisions/0001-exo-variant-export-storage-shape.md), so their count
+        // Fragment rather than exported as their own top-level field, so their count
         // isn't free from resultTypes above and is computed here instead.
         if (ctx.data.experiences?.some((experience) => experience.optimizationVariants)) {
           const count = ctx.data.experiences.reduce((sum, experience) => sum + (experience.optimizationVariants?.length ?? 0), 0)

--- a/lib/index.js
+++ b/lib/index.js
@@ -166,14 +166,23 @@ export default function runContentfulExport (params) {
 
         // Optimization Variants are nested onto their parent Experience/Experience
         // Fragment rather than exported as their own top-level field, so their count
-        // isn't free from resultTypes above and is computed here instead.
+        // isn't free from resultTypes above and is computed here instead. A per-parent
+        // fetch failure falls back to an empty optimizationVariants array, which is
+        // indistinguishable from a parent that genuinely has none -- so failures are
+        // surfaced as their own row rather than folded silently into the count.
         if (ctx.data.experiences?.some((experience) => experience.optimizationVariants)) {
           const count = ctx.data.experiences.reduce((sum, experience) => sum + (experience.optimizationVariants?.length ?? 0), 0)
           resultTable.push(['Experience Optimization Variants', count])
         }
+        if (ctx.optimizationVariantFailures?.experiences) {
+          resultTable.push(['Experience Optimization Variant Fetch Failures', ctx.optimizationVariantFailures.experiences])
+        }
         if (ctx.data.experienceFragments?.some((experienceFragment) => experienceFragment.optimizationVariants)) {
           const count = ctx.data.experienceFragments.reduce((sum, experienceFragment) => sum + (experienceFragment.optimizationVariants?.length ?? 0), 0)
           resultTable.push(['Experience Fragment Optimization Variants', count])
+        }
+        if (ctx.optimizationVariantFailures?.experienceFragments) {
+          resultTable.push(['Experience Fragment Optimization Variant Fetch Failures', ctx.optimizationVariantFailures.experienceFragments])
         }
 
         console.log(resultTable.toString())

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -22,6 +22,7 @@ export default function parseOptions (params) {
     stripTags: false,
     maxAllowedLimit: 1000,
     includeExperienceOrchestration: true,
+    includeExoVariants: false,
     saveFile: true,
     useVerboseRenderer: false,
     rawProxy: false

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -314,6 +314,12 @@ async function cursorPagedGet(fetchFn, entityLabel) {
  * total/pages fields, just { sys: { type: 'Array' }, items }. So this is a single
  * request per parent, not a paging loop.
  *
+ * The API always leads the list with a `sys.variantType: 'default'` item representing
+ * the parent's own base view (either a real record, or the baseline Experience/Fragment
+ * itself if none exists) — not a real personalization variant. That entity is already
+ * exported as its own top-level Experience/ExperienceFragment, so it's filtered out here
+ * to avoid double-counting it as a variant.
+ *
  * Runs with bounded concurrency (mirrors getEditorInterfaces' pattern) since this
  * issues one request per parent entity (N+1).
  */
@@ -327,8 +333,8 @@ async function attachOptimizationVariants ({ parents, fetchFn, entityLabel }) {
   await Promise.map(parents, async (parent) => {
     try {
       const response = await fetchFn(parent.sys.id, {})
-      parent.optimizationVariants = response.items
-      totalFetched += response.items.length
+      parent.optimizationVariants = response.items.filter((item) => item.sys.variantType !== 'default')
+      totalFetched += parent.optimizationVariants.length
       logEmitter.emit('info', `Fetched ${totalFetched} ${entityLabel} items`)
     } catch (err) {
       logEmitter.emit('warning', `Skipping ${entityLabel} export for ${parent.sys.id}: ${err.message}`)

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -27,6 +27,7 @@ export default function getFullSourceSpace({
   includeArchived,
   maxAllowedLimit,
   includeExperienceOrchestration,
+  includeExoVariants,
   listrOptions,
   queryEntries,
   queryAssets
@@ -233,6 +234,28 @@ export default function getFullSourceSpace({
         }
       }),
       skip: () => !includeExperienceOrchestration
+    },
+    {
+      title: 'Fetching Experience Optimization Variants data',
+      task: wrapTask(async (ctx) => {
+        await attachOptimizationVariants({
+          parents: ctx.data.experiences,
+          fetchFn: (parentId, query) => client.experienceVariant.getMany({ spaceId, environmentId, experienceId: parentId, query }),
+          entityLabel: 'Experience Optimization Variants'
+        })
+      }),
+      skip: () => !includeExperienceOrchestration || !includeExoVariants
+    },
+    {
+      title: 'Fetching Experience Fragment Optimization Variants data',
+      task: wrapTask(async (ctx) => {
+        await attachOptimizationVariants({
+          parents: ctx.data.experienceFragments,
+          fetchFn: (parentId, query) => client.experienceFragmentVariant.getMany({ spaceId, environmentId, experienceFragmentId: parentId, query }),
+          entityLabel: 'Experience Fragment Optimization Variants'
+        })
+      }),
+      skip: () => !includeExperienceOrchestration || !includeExoVariants
     }
   ], listrOptions)
 }
@@ -275,6 +298,45 @@ async function cursorPagedGet(fetchFn, entityLabel) {
   } while (pageNext)
 
   return allItems
+}
+
+/**
+ * Fetches and attaches Optimization Variants onto each of a parent entity type's
+ * items (Experience or ExperienceFragment), mutating them in place as
+ * `parent.optimizationVariants`. Variants are nested onto their parent rather than
+ * exported as their own top-level field because a variant's `sys.id` is borrowed
+ * from its parent (not unique to the variant), so a flat array would collide the
+ * way none of the other ExO entity types do — see
+ * projects/decisions/0001-exo-variant-export-storage-shape.md in the ecosystem-os repo.
+ *
+ * Unlike the top-level ExO entities, the optimization_variants list endpoint is NOT
+ * cursor-paginated — it takes no limit/pageNext query params and its response has no
+ * total/pages fields, just { sys: { type: 'Array' }, items }. So this is a single
+ * request per parent, not a paging loop.
+ *
+ * Runs with bounded concurrency (mirrors getEditorInterfaces' pattern) since this
+ * issues one request per parent entity (N+1).
+ */
+async function attachOptimizationVariants ({ parents, fetchFn, entityLabel }) {
+  if (!parents?.length) {
+    return
+  }
+
+  let totalFetched = 0
+
+  await Promise.map(parents, async (parent) => {
+    try {
+      const response = await fetchFn(parent.sys.id, {})
+      parent.optimizationVariants = response.items
+      totalFetched += response.items.length
+      logEmitter.emit('info', `Fetched ${totalFetched} ${entityLabel} items`)
+    } catch (err) {
+      logEmitter.emit('warning', `Skipping ${entityLabel} export for ${parent.sys.id}: ${err.message}`)
+      parent.optimizationVariants = []
+    }
+  }, {
+    concurrency: 6
+  })
 }
 
 /**

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -306,8 +306,7 @@ async function cursorPagedGet(fetchFn, entityLabel) {
  * `parent.optimizationVariants`. Variants are nested onto their parent rather than
  * exported as their own top-level field because a variant's `sys.id` is borrowed
  * from its parent (not unique to the variant), so a flat array would collide the
- * way none of the other ExO entity types do — see
- * projects/decisions/0001-exo-variant-export-storage-shape.md in the ecosystem-os repo.
+ * way none of the other ExO entity types do.
  *
  * Unlike the top-level ExO entities, the optimization_variants list endpoint is NOT
  * cursor-paginated — it takes no limit/pageNext query params and its response has no

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -238,22 +238,26 @@ export default function getFullSourceSpace({
     {
       title: 'Fetching Experience Optimization Variants data',
       task: wrapTask(async (ctx) => {
-        await attachOptimizationVariants({
+        const experienceFailureCount = await attachOptimizationVariants({
           parents: ctx.data.experiences,
           fetchFn: (parentId, query) => client.experienceVariant.getMany({ spaceId, environmentId, experienceId: parentId, query }),
           entityLabel: 'Experience Optimization Variants'
         })
+        ctx.optimizationVariantFailures = ctx.optimizationVariantFailures || {}
+        ctx.optimizationVariantFailures.experiences = experienceFailureCount
       }),
       skip: () => !includeExperienceOrchestration || !includeExoVariants
     },
     {
       title: 'Fetching Experience Fragment Optimization Variants data',
       task: wrapTask(async (ctx) => {
-        await attachOptimizationVariants({
+        const experienceFragmentFailureCount = await attachOptimizationVariants({
           parents: ctx.data.experienceFragments,
           fetchFn: (parentId, query) => client.experienceFragmentVariant.getMany({ spaceId, environmentId, experienceFragmentId: parentId, query }),
           entityLabel: 'Experience Fragment Optimization Variants'
         })
+        ctx.optimizationVariantFailures = ctx.optimizationVariantFailures || {}
+        ctx.optimizationVariantFailures.experienceFragments = experienceFragmentFailureCount
       }),
       skip: () => !includeExperienceOrchestration || !includeExoVariants
     }
@@ -321,13 +325,18 @@ async function cursorPagedGet(fetchFn, entityLabel) {
  *
  * Runs with bounded concurrency (mirrors getEditorInterfaces' pattern) since this
  * issues one request per parent entity (N+1).
+ *
+ * Returns the count of parents whose variant fetch failed, so callers can
+ * surface that distinctly from a parent that genuinely has zero variants
+ * (both look identical as an empty `optimizationVariants` array otherwise).
  */
 async function attachOptimizationVariants ({ parents, fetchFn, entityLabel }) {
   if (!parents?.length) {
-    return
+    return 0
   }
 
   let totalFetched = 0
+  let failureCount = 0
 
   await Promise.map(parents, async (parent) => {
     try {
@@ -338,10 +347,13 @@ async function attachOptimizationVariants ({ parents, fetchFn, entityLabel }) {
     } catch (err) {
       logEmitter.emit('warning', `Skipping ${entityLabel} export for ${parent.sys.id}: ${err.message}`)
       parent.optimizationVariants = []
+      failureCount++
     }
   }, {
     concurrency: 6
   })
+
+  return failureCount
 }
 
 /**

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -136,6 +136,11 @@ export default yargs
     type: 'boolean',
     default: true
   })
+  .option('include-exo-variants', {
+    describe: 'Include Optimization Variants, nested onto their parent Experience/Experience Fragment as `optimizationVariants`. Requires include-experience-orchestration and the Contentful Personalization app on the source space.',
+    type: 'boolean',
+    default: false
+  })
   .option('header', {
     alias: 'H',
     type: 'string',

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -137,7 +137,7 @@ export default yargs
     default: true
   })
   .option('include-exo-variants', {
-    describe: 'Include Optimization Variants, nested onto their parent Experience/Experience Fragment as `optimizationVariants`. Requires include-experience-orchestration and the Contentful Personalization app on the source space.',
+    describe: 'Include Optimization Variants, nested onto their parent Experience/Experience Fragment as `optimizationVariants`. Requires include-experience-orchestration. Only has an effect if the Contentful Personalization app is installed on the source space.',
     type: 'boolean',
     default: false
   })

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "cli-table3": "^0.6.0",
         "contentful": "^11.5.10",
         "contentful-batch-libs": "^12.0.0",
-        "contentful-management": "^12.14.0",
+        "contentful-management": "file:/tmp/cma-fix/contentful-management-0.0.0-determined-by-semantic-release.tgz",
         "date-fns": "^4.1.0",
         "figures": "^3.2.0",
         "jsonwebtoken": "^9.0.0",
@@ -6131,9 +6131,9 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.14.0.tgz",
-      "integrity": "sha512-Xm25+vDcmwaPwRga+IkGczHzDcyn+fmXQlFh7w0SLsxcWHnkDJU8Sp9HXHDad6vkGJKwxEnOL0DKdHACJlR1fw==",
+      "version": "0.0.0-determined-by-semantic-release",
+      "resolved": "file:../../../../../../tmp/cma-fix/contentful-management-0.0.0-determined-by-semantic-release.tgz",
+      "integrity": "sha512-+E/oAPrGMA/0d9sgQ0ZNUe5NOmWh/sTaLTBoISGJoqNX1rhENGxg/UeueSRXKztitDCvvKhlLcz1nPrSnR7NSA==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "cli-table3": "^0.6.0",
         "contentful": "^11.5.10",
         "contentful-batch-libs": "^12.0.0",
-        "contentful-management": "file:/tmp/cma-fix/contentful-management-0.0.0-determined-by-semantic-release.tgz",
+        "contentful-management": "^12.17.0",
         "date-fns": "^4.1.0",
         "figures": "^3.2.0",
         "jsonwebtoken": "^9.0.0",
@@ -6131,9 +6131,9 @@
       }
     },
     "node_modules/contentful-management": {
-      "version": "0.0.0-determined-by-semantic-release",
-      "resolved": "file:../../../../../../tmp/cma-fix/contentful-management-0.0.0-determined-by-semantic-release.tgz",
-      "integrity": "sha512-+E/oAPrGMA/0d9sgQ0ZNUe5NOmWh/sTaLTBoISGJoqNX1rhENGxg/UeueSRXKztitDCvvKhlLcz1nPrSnR7NSA==",
+      "version": "12.17.0",
+      "resolved": "https://registry.npmjs.org/contentful-management/-/contentful-management-12.17.0.tgz",
+      "integrity": "sha512-ddp/0iXmw5X/lo3kWmFMIc2A4koWN5eF8xnAN6qAKIaaVFxfOyWgOe1mTetbpkMC5R/+XLVFC44Z2kuTWDmF3Q==",
       "license": "MIT",
       "dependencies": {
         "@contentful/rich-text-types": "^16.6.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cli-table3": "^0.6.0",
     "contentful": "^11.5.10",
     "contentful-batch-libs": "^12.0.0",
-    "contentful-management": "^12.14.0",
+    "contentful-management": "file:/tmp/cma-fix/contentful-management-0.0.0-determined-by-semantic-release.tgz",
     "date-fns": "^4.1.0",
     "figures": "^3.2.0",
     "jsonwebtoken": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cli-table3": "^0.6.0",
     "contentful": "^11.5.10",
     "contentful-batch-libs": "^12.0.0",
-    "contentful-management": "file:/tmp/cma-fix/contentful-management-0.0.0-determined-by-semantic-release.tgz",
+    "contentful-management": "^12.17.0",
     "date-fns": "^4.1.0",
     "figures": "^3.2.0",
     "jsonwebtoken": "^9.0.0",

--- a/test/integration/export-exo.test.js
+++ b/test/integration/export-exo.test.js
@@ -209,7 +209,7 @@ beforeAll(async () => {
   // Optimization Variant (1) on Fragment A only -- Fragment B is left without one to also
   // cover the zero-variants case (optimizationVariants should be [], not undefined, and must
   // not include the API-synthesized `variantType: 'default'` entry representing the parent
-  // itself -- see AIS-139 / projects/decisions/0001-exo-variant-export-storage-shape.md).
+  // itself -- see AIS-139).
   const fragmentAVariant = await client.experienceFragmentVariant.create(
     { experienceFragmentId: publishedFragmentA.sys.id },
     {

--- a/test/integration/export-exo.test.js
+++ b/test/integration/export-exo.test.js
@@ -206,6 +206,21 @@ beforeAll(async () => {
   )
   const publishedFragmentA = await client.experienceFragment.publish({ experienceFragmentId: fragmentA.sys.id, version: fragmentA.sys.version })
 
+  // Optimization Variant (1) on Fragment A only -- Fragment B is left without one to also
+  // cover the zero-variants case (optimizationVariants should be [], not undefined, and must
+  // not include the API-synthesized `variantType: 'default'` entry representing the parent
+  // itself -- see AIS-139 / projects/decisions/0001-exo-variant-export-storage-shape.md).
+  const fragmentAVariant = await client.experienceFragmentVariant.create(
+    { experienceFragmentId: publishedFragmentA.sys.id },
+    {
+      name: 'Fragment A Variant',
+      description: 'Optimization variant of Fragment A',
+      viewports: [VIEWPORT],
+      designProperties: {},
+      component: resourceLink('Contentful:Component', componentUrn(publishedBaseComponent.sys.id))
+    }
+  )
+
   const compositeComponent = await client.component.create(
     {},
     {
@@ -321,6 +336,19 @@ beforeAll(async () => {
   )
   const publishedExperienceA = await client.experience.publish({ experienceId: experienceA.sys.id, version: experienceA.sys.version })
 
+  // Optimization Variant (1) on Experience A only -- Experience B is left without one, same
+  // zero-variants coverage rationale as Fragment B above.
+  const experienceAVariant = await client.experienceVariant.create(
+    { experienceId: publishedExperienceA.sys.id },
+    {
+      name: 'Experience A Variant',
+      description: 'Optimization variant of Experience A',
+      viewports: [VIEWPORT],
+      designProperties: {},
+      experienceTemplate: resourceLink('Contentful:ExperienceTemplate', `${EXO_URN_BASE}/experienceTemplates/${publishedTemplateA.sys.id}`)
+    }
+  )
+
   const experienceB = await client.experience.create(
     {},
     {
@@ -363,6 +391,45 @@ describe('Experience Orchestration', () => {
       const exportedFragmentB = content.experienceFragments.find((f) => f.name === 'Fragment B')
       expect(exportedFragmentB.contentBindings.sys.urn).toBe(dataAssemblyUrn(createdIds.dataAssemblies[1]))
       expect(exportedFragmentB.contentBindings.parameters.p_entry.sys.urn).toBe(entryUrn(entryId))
+
+      // includeExoVariants defaults to false -- optimizationVariants must be absent
+      // entirely (not an empty array) when the flag isn't passed.
+      expect('optimizationVariants' in content.experiences[0]).toBe(false)
+      expect('optimizationVariants' in content.experienceFragments[0]).toBe(false)
+    })
+  })
+
+  it('nests Optimization Variants onto their parent when includeExoVariants is true, excluding the API-synthesized default entry', () => {
+    return runContentfulExport({
+      spaceId,
+      managementToken,
+      saveFile: false,
+      exportDir: tmpFolder,
+      includeExperienceOrchestration: true,
+      includeExoVariants: true
+    }).then((content) => {
+      const exportedExperienceA = content.experiences.find((e) => e.name === 'Experience A')
+      const exportedExperienceB = content.experiences.find((e) => e.name === 'Experience B')
+      const exportedFragmentA = content.experienceFragments.find((f) => f.name === 'Fragment A')
+      const exportedFragmentB = content.experienceFragments.find((f) => f.name === 'Fragment B')
+
+      // Experience A / Fragment A each got exactly one real variant seeded above --
+      // optimizationVariants must contain exactly that variant, not the parent's own
+      // `variantType: 'default'` view (which the API always leads the list with).
+      expect(exportedExperienceA.optimizationVariants).toHaveLength(1)
+      expect(exportedExperienceA.optimizationVariants[0].name).toBe('Experience A Variant')
+      expect(exportedExperienceA.optimizationVariants[0].sys.variantType).toBe('personalization')
+      expect(exportedExperienceA.optimizationVariants[0].sys.id).toBe(exportedExperienceA.sys.id)
+
+      expect(exportedFragmentA.optimizationVariants).toHaveLength(1)
+      expect(exportedFragmentA.optimizationVariants[0].name).toBe('Fragment A Variant')
+      expect(exportedFragmentA.optimizationVariants[0].sys.variantType).toBe('personalization')
+      expect(exportedFragmentA.optimizationVariants[0].sys.id).toBe(exportedFragmentA.sys.id)
+
+      // Experience B / Fragment B got no variants seeded -- optimizationVariants must be
+      // [], not undefined and not [default-pseudo-variant].
+      expect(exportedExperienceB.optimizationVariants).toEqual([])
+      expect(exportedFragmentB.optimizationVariants).toEqual([])
     })
   })
 })

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -2,6 +2,7 @@ import { resolve } from 'path'
 
 import bfj from 'bfj'
 import fs from 'fs'
+import Listr from 'listr'
 import mkdirp from 'mkdirp'
 
 import {
@@ -141,6 +142,58 @@ test('Creates a valid and correct opts object', async () => {
   expect(exportedTable[0]).toMatch(/Entries.+0/)
   expect(exportedTable[0]).toMatch(/Assets.+2/)
   expect(exportedTable[0]).toMatch(/Locales.+0/)
+})
+
+test('Adds a computed row to the summary table for nested Optimization Variants', async () => {
+  // Variants are nested onto their parent (projects/decisions/0001-exo-variant-export-storage-shape.md,
+  // ecosystem-os repo), so they have no top-level ctx.data field and their count isn't
+  // free from the generic per-field loop in lib/index.js — this exercises the computed
+  // rows added specifically to cover that.
+  getSpaceData.mockImplementationOnce(() => new Listr([
+    {
+      title: 'mocked get full source space with variants',
+      task: (ctx) => {
+        ctx.data = {
+          contentTypes: [],
+          entries: [],
+          assets: [],
+          locales: [],
+          experiences: [
+            { sys: { id: 'exp1' }, optimizationVariants: [{ sys: { id: 'exp1', variant: 'v1' } }, { sys: { id: 'exp1', variant: 'v2' } }] },
+            { sys: { id: 'exp2' }, optimizationVariants: [] }
+          ],
+          experienceFragments: [
+            { sys: { id: 'frag1' }, optimizationVariants: [{ sys: { id: 'frag1', variant: 'v1' } }] }
+          ]
+        }
+      }
+    }
+  ]))
+
+  await runContentfulExport({
+    errorLogFile: 'errorlogfile',
+    spaceId: 'someSpaceId',
+    managementToken: 'someManagementToken'
+  })
+
+  const exportedTable = global.console.log.mock.calls.find((call) => call[0].match(/Exported entities/))
+  expect(exportedTable).not.toBeUndefined()
+  expect(exportedTable[0]).toMatch(/Experiences.+2/)
+  expect(exportedTable[0]).toMatch(/Experience Fragments.+1/)
+  expect(exportedTable[0]).toMatch(/Experience Optimization Variants.+2/)
+  expect(exportedTable[0]).toMatch(/Experience Fragment Optimization Variants.+1/)
+})
+
+test('Omits the variant summary rows when no parent has optimizationVariants', async () => {
+  await runContentfulExport({
+    errorLogFile: 'errorlogfile',
+    spaceId: 'someSpaceId',
+    managementToken: 'someManagementToken'
+  })
+
+  const exportedTable = global.console.log.mock.calls.find((call) => call[0].match(/Exported entities/))
+  expect(exportedTable).not.toBeUndefined()
+  expect(exportedTable[0]).not.toMatch(/Optimization Variants/)
 })
 
 test('Run Contentful export fails due to rejection', async () => {

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -183,6 +183,41 @@ test('Adds a computed row to the summary table for nested Optimization Variants'
   expect(exportedTable[0]).toMatch(/Experience Fragment Optimization Variants.+1/)
 })
 
+test('Adds a fetch-failure row to the summary table when a variant fetch failed', async () => {
+  // A per-parent variant fetch failure falls back to optimizationVariants: [], which
+  // looks identical to a parent that genuinely has zero variants. The failure count
+  // must show up as its own row rather than being folded silently into that count.
+  getSpaceData.mockImplementationOnce(() => new Listr([
+    {
+      title: 'mocked get full source space with a variant fetch failure',
+      task: (ctx) => {
+        ctx.data = {
+          contentTypes: [],
+          entries: [],
+          assets: [],
+          locales: [],
+          experiences: [
+            { sys: { id: 'exp1' }, optimizationVariants: [] }
+          ],
+          experienceFragments: []
+        }
+        ctx.optimizationVariantFailures = { experiences: 1, experienceFragments: 0 }
+      }
+    }
+  ]))
+
+  await runContentfulExport({
+    errorLogFile: 'errorlogfile',
+    spaceId: 'someSpaceId',
+    managementToken: 'someManagementToken'
+  })
+
+  const exportedTable = global.console.log.mock.calls.find((call) => call[0].match(/Exported entities/))
+  expect(exportedTable).not.toBeUndefined()
+  expect(exportedTable[0]).toMatch(/Experience Optimization Variant Fetch Failures.+1/)
+  expect(exportedTable[0]).not.toMatch(/Experience Fragment Optimization Variant Fetch Failures/)
+})
+
 test('Omits the variant summary rows when no parent has optimizationVariants', async () => {
   await runContentfulExport({
     errorLogFile: 'errorlogfile',

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -145,10 +145,9 @@ test('Creates a valid and correct opts object', async () => {
 })
 
 test('Adds a computed row to the summary table for nested Optimization Variants', async () => {
-  // Variants are nested onto their parent (projects/decisions/0001-exo-variant-export-storage-shape.md,
-  // ecosystem-os repo), so they have no top-level ctx.data field and their count isn't
-  // free from the generic per-field loop in lib/index.js — this exercises the computed
-  // rows added specifically to cover that.
+  // Variants are nested onto their parent, so they have no top-level ctx.data field
+  // and their count isn't free from the generic per-field loop in lib/index.js — this
+  // exercises the computed rows added specifically to cover that.
   getSpaceData.mockImplementationOnce(() => new Listr([
     {
       title: 'mocked get full source space with variants',

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -1112,3 +1112,50 @@ test('Skips Experience/Fragment variant fetch entirely when there are no parents
       expect(mockClient.experienceFragmentVariant.getMany.mock.calls).toHaveLength(0)
     })
 })
+
+test('Filters out the API-synthesized default pseudo-variant, which represents the parent itself', () => {
+  // The optimization_variants list endpoint always leads with a sys.variantType: 'default'
+  // item representing the parent's own base view (a real record, or the baseline
+  // Experience/Fragment itself if none exists) -- not a real personalization variant.
+  // That entity is already exported as its own top-level Experience/ExperienceFragment, so
+  // it must not also show up inside optimizationVariants (double-counting it as a variant).
+  setupExoMocks()
+  mockClient.experience.getMany = jest.fn(() => Promise.resolve(cursorPage([{ sys: { id: 'exp1' } }])))
+  mockClient.experienceFragment.getMany = jest.fn(() => Promise.resolve(cursorPage([{ sys: { id: 'frag1' } }])))
+  mockClient.experienceVariant = {
+    getMany: jest.fn(() => Promise.resolve({
+      sys: { type: 'Array' },
+      items: [
+        { sys: { id: 'exp1', variant: 'default', variantType: 'default' } },
+        { sys: { id: 'exp1', variant: 'v1', variantType: 'personalization' } }
+      ]
+    }))
+  }
+  mockClient.experienceFragmentVariant = {
+    // A parent with zero real variants still gets the synthesized default entry back --
+    // filtering it must leave optimizationVariants empty, not length 1.
+    getMany: jest.fn(() => Promise.resolve({
+      sys: { type: 'Array' },
+      items: [{ sys: { id: 'frag1', variant: 'default', variantType: 'default' } }]
+    }))
+  }
+
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    skipContent: true,
+    skipWebhooks: true,
+    skipRoles: true,
+    includeExperienceOrchestration: true,
+    includeExoVariants: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      expect(response.data.experiences[0].optimizationVariants)
+        .toEqual([{ sys: { id: 'exp1', variant: 'v1', variantType: 'personalization' } }])
+      expect(response.data.experienceFragments[0].optimizationVariants).toEqual([])
+    })
+})

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -945,3 +945,170 @@ test('Degrades gracefully to an empty array when an ExO endpoint fails', () => {
       expect(response.data.designTokens).toHaveLength(1)
     })
 })
+
+// --- Optimization Variants ---
+//
+// Variants are nested onto their parent Experience/ExperienceFragment
+// (`parent.optimizationVariants`), not exported as their own top-level field — see
+// projects/decisions/0001-exo-variant-export-storage-shape.md (ecosystem-os repo).
+// This is because a variant's `sys.id` is borrowed from its parent (not unique to
+// the variant itself), so a flat array would collide; nesting sidesteps that by
+// construction. These tests exist specifically to guard that nesting behavior and
+// its gating.
+
+function setupVariantMocks() {
+  mockClient.experienceVariant = {
+    getMany: jest.fn(() => Promise.resolve({ sys: { type: 'Array' }, items: [] }))
+  }
+  mockClient.experienceFragmentVariant = {
+    getMany: jest.fn(() => Promise.resolve({ sys: { type: 'Array' }, items: [] }))
+  }
+}
+
+test('Skips Optimization Variants by default even when ExO is enabled', () => {
+  setupExoMocks()
+  setupVariantMocks()
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    skipContent: true,
+    skipWebhooks: true,
+    skipRoles: true,
+    includeExperienceOrchestration: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      expect(mockClient.experienceVariant.getMany.mock.calls).toHaveLength(0)
+      expect(mockClient.experienceFragmentVariant.getMany.mock.calls).toHaveLength(0)
+      expect(response.data.experiences[0].optimizationVariants).toBeUndefined()
+      expect(response.data.experienceFragments[0].optimizationVariants).toBeUndefined()
+    })
+})
+
+test('Nests fetched variants onto their parent Experience/ExperienceFragment when includeExoVariants is true', () => {
+  setupExoMocks()
+  mockClient.experience.getMany = jest.fn(() => Promise.resolve(
+    cursorPage([{ sys: { id: 'exp1' } }, { sys: { id: 'exp2' } }])
+  ))
+  mockClient.experienceFragment.getMany = jest.fn(() => Promise.resolve(
+    cursorPage([{ sys: { id: 'frag1' } }])
+  ))
+  mockClient.experienceVariant = {
+    getMany: jest.fn((params) => Promise.resolve({
+      sys: { type: 'Array' },
+      items: [{ sys: { id: params.experienceId, variant: `${params.experienceId}-v1` } }]
+    }))
+  }
+  mockClient.experienceFragmentVariant = {
+    getMany: jest.fn((params) => Promise.resolve({
+      sys: { type: 'Array' },
+      items: [{ sys: { id: params.experienceFragmentId, variant: `${params.experienceFragmentId}-v1` } }]
+    }))
+  }
+
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    skipContent: true,
+    skipWebhooks: true,
+    skipRoles: true,
+    includeExperienceOrchestration: true,
+    includeExoVariants: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      // One call per parent (N+1), each scoped by that parent's ID via the
+      // endpoint-specific param name (experienceId vs experienceFragmentId).
+      expect(mockClient.experienceVariant.getMany.mock.calls).toHaveLength(2)
+      expect(mockClient.experienceVariant.getMany.mock.calls[0][0]).toEqual({
+        spaceId: 'spaceid',
+        environmentId: 'master',
+        experienceId: 'exp1',
+        query: {}
+      })
+      expect(mockClient.experienceFragmentVariant.getMany.mock.calls).toHaveLength(1)
+      expect(mockClient.experienceFragmentVariant.getMany.mock.calls[0][0]).toEqual({
+        spaceId: 'spaceid',
+        environmentId: 'master',
+        experienceFragmentId: 'frag1',
+        query: {}
+      })
+      // Variants land nested on their own parent, not as a top-level field, and
+      // not cross-mixed between the two parents fetched in the same run.
+      expect(response.data.experiences.find((e) => e.sys.id === 'exp1').optimizationVariants)
+        .toEqual([{ sys: { id: 'exp1', variant: 'exp1-v1' } }])
+      expect(response.data.experiences.find((e) => e.sys.id === 'exp2').optimizationVariants)
+        .toEqual([{ sys: { id: 'exp2', variant: 'exp2-v1' } }])
+      expect(response.data.experienceFragments[0].optimizationVariants)
+        .toEqual([{ sys: { id: 'frag1', variant: 'frag1-v1' } }])
+      expect(response.data.experienceVariants).toBeUndefined()
+      expect(response.data.experienceFragmentVariants).toBeUndefined()
+    })
+})
+
+test('Degrades gracefully to an empty array when a single parent\'s variant fetch fails', () => {
+  setupExoMocks()
+  mockClient.experience.getMany = jest.fn(() => Promise.resolve(
+    cursorPage([{ sys: { id: 'exp1' } }, { sys: { id: 'exp2' } }])
+  ))
+  mockClient.experienceVariant = {
+    getMany: jest.fn((params) => params.experienceId === 'exp1'
+      ? Promise.reject(new Error('missing entitlement'))
+      : Promise.resolve({ sys: { type: 'Array' }, items: [{ sys: { id: 'exp2', variant: 'exp2-v1' } }] }))
+  }
+  mockClient.experienceFragmentVariant = {
+    getMany: jest.fn(() => Promise.resolve({ sys: { type: 'Array' }, items: [] }))
+  }
+
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    skipContent: true,
+    skipWebhooks: true,
+    skipRoles: true,
+    includeExperienceOrchestration: true,
+    includeExoVariants: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      // The failing parent gets [] rather than aborting the whole export...
+      expect(response.data.experiences.find((e) => e.sys.id === 'exp1').optimizationVariants).toEqual([])
+      // ...and the other parent's variants are still fetched.
+      expect(response.data.experiences.find((e) => e.sys.id === 'exp2').optimizationVariants)
+        .toEqual([{ sys: { id: 'exp2', variant: 'exp2-v1' } }])
+    })
+})
+
+test('Skips Experience/Fragment variant fetch entirely when there are no parents to fetch for', () => {
+  setupExoMocks()
+  mockClient.experience.getMany = jest.fn(() => Promise.resolve(cursorPage([])))
+  mockClient.experienceFragment.getMany = jest.fn(() => Promise.resolve(cursorPage([])))
+  setupVariantMocks()
+
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    skipContent: true,
+    skipWebhooks: true,
+    skipRoles: true,
+    includeExperienceOrchestration: true,
+    includeExoVariants: true
+  })
+    .run({
+      data: {}
+    })
+    .then(() => {
+      expect(mockClient.experienceVariant.getMany.mock.calls).toHaveLength(0)
+      expect(mockClient.experienceFragmentVariant.getMany.mock.calls).toHaveLength(0)
+    })
+})

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -1084,6 +1084,10 @@ test('Degrades gracefully to an empty array when a single parent\'s variant fetc
       // ...and the other parent's variants are still fetched.
       expect(response.data.experiences.find((e) => e.sys.id === 'exp2').optimizationVariants)
         .toEqual([{ sys: { id: 'exp2', variant: 'exp2-v1' } }])
+      // The failure is counted separately so it isn't indistinguishable from a
+      // parent that genuinely has zero variants.
+      expect(response.optimizationVariantFailures.experiences).toBe(1)
+      expect(response.optimizationVariantFailures.experienceFragments).toBe(0)
     })
 })
 

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -949,8 +949,7 @@ test('Degrades gracefully to an empty array when an ExO endpoint fails', () => {
 // --- Optimization Variants ---
 //
 // Variants are nested onto their parent Experience/ExperienceFragment
-// (`parent.optimizationVariants`), not exported as their own top-level field — see
-// projects/decisions/0001-exo-variant-export-storage-shape.md (ecosystem-os repo).
+// (`parent.optimizationVariants`), not exported as their own top-level field.
 // This is because a variant's `sys.id` is borrowed from its parent (not unique to
 // the variant itself), so a flat array would collide; nesting sidesteps that by
 // construction. These tests exist specifically to guard that nesting behavior and


### PR DESCRIPTION
[AIS-139](https://contentful.atlassian.net/browse/AIS-139)

## Summary
- Adds a new opt-in `includeExoVariants` flag (default `false`) that exports Experience and Experience Fragment Optimization Variants, nested onto their parent as `experience.optimizationVariants` / `experienceFragment.optimizationVariants`.
- Variants aren't exported as their own top-level array like the other six ExO entity types. That's deliberate: a variant's `sys.id` is borrowed from its parent rather than being globally unique, so a flat array would let two variants collide under the same ID.
- The API's response for a parent's variant list always includes an extra entry representing the parent's own base view (`variantType: 'default'`). That's not a real variant, so it's filtered out — `optimizationVariants` only ever contains actual personalization variants.
- Also included: live integration test coverage against a real space, README/doc updates explaining the shape, and a dependency swap from a local workaround package to the real published `contentful-management@^12.17.0` (the first release with the variant SDK methods this depends on: [#3126](https://github.com/contentful/contentful-management.js/pull/3126), [#3127](https://github.com/contentful/contentful-management.js/pull/3127)).

## Test plan
- [x] Unit suite passes (68/68), including new coverage for the variant-fetching logic and the default-entry filter
- [x] New integration test run live against a real space — confirms the seeded variants export correctly, the default entry is excluded, and `optimizationVariants` is absent entirely (not `[]`) when the flag is off
- [x] Manually verified a full export → import round trip against a real sandbox space, paired with the corresponding `contentful-import` branch

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-139]: https://contentful.atlassian.net/browse/AIS-139?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ