### PR TITLE
feat: support experience releases export [AIS-140]

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,10 @@ Skip exporting tags
 
 Skip exporting webhooks
 
+#### `skipReleases` [boolean] [default: false]
+
+Skip exporting [Releases](https://www.contentful.com/help/releases/). See the "Releases" section below for what's exported when this is on.
+
 #### `stripTags` [boolean] [default: false]
 
 Untag assets and entries
@@ -339,6 +343,7 @@ This is an overview of the exported data:
   "webhooks": [],
   "roles": [],
   "editorInterfaces": [],
+  "releases": [],
   "designTokens": [],
   "components": [],
   "experienceTemplates": [],
@@ -364,6 +369,8 @@ When `includeExperienceOrchestration: true` is set, six additional arrays are in
 _Note:_ Tags feature is not available for all users. If you do not have access to this feature, the tags array will always be empty.
 
 _Note:_ `designTokens`, `components`, `experienceTemplates`, `dataAssemblies`, `experienceFragments`, and `experiences` are Experience Orchestration (ExO) entities — present by default; absent only if you explicitly set `includeExperienceOrchestration: false` — see the "Experience Orchestration (ExO) entities" section below.
+
+_Note:_ `releases` is present by default; absent only if you explicitly set `skipReleases: true` — see the "Releases" section below. It's a separate, GA Contentful feature, not part of ExO.
 
 ## :test_tube: Experience Orchestration (ExO) entities
 
@@ -392,6 +399,18 @@ Requires the `exoM1` entitlement on the source space's organization. [contentful
 ### Round-tripping into `contentful-import`
 
 The ExO entities exported here are designed to be fed directly into [`contentful-import`](https://github.com/contentful/contentful-import), which preserves source IDs, applies dependency ordering (a topological sort for Components and Experience Fragments, since either can reference others of the same type), and upgrades entities from older, pre-rename export files automatically. See `contentful-import`'s README "Experience Orchestration (ExO) entities" section for the import-side details.
+
+## :package: Releases
+
+[Releases](https://www.contentful.com/help/releases/) (Timeline) is a separate, GA Contentful feature — not part of Experience Orchestration, and gated by its own organization entitlement rather than `exoM1`.
+
+Releases export is on by default (`skipReleases: false`) — for the CLI and the module API alike. Pass `skipReleases: true` (`--skip-releases` on the CLI) to opt out.
+
+Only releases with `sys.schemaVersion: "Release.v2"` ("Releases") are fetched. `Release.v1` ("Launch") releases are excluded by the export query itself, since [`contentful-import`](https://github.com/contentful/contentful-import) only supports `Release.v2` on the import side.
+
+If the source space's organization lacks the Releases entitlement, or the fetch otherwise fails, a `Skipping Releases export` warning is logged and `releases` exports as an empty array — it does not fail the export.
+
+Round-trips into [`contentful-import`](https://github.com/contentful/contentful-import), which imports each release found in the exported data. See `contentful-import`'s README "Releases" section for the import-side details, including a real limitation worth knowing before you rely on this for repeated imports: Releases have no ID-preserving create, so re-importing the same export creates additional releases rather than updating existing ones.
 
 ## :warning: Limitations
 

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Content Delivery API.
 
 #### `includeArchived` [boolean] [default: false]
 
-Include archived entries in the exported entries
+Include archived entries and assets in the exported data. This option does not include archived Releases.
 
 #### `skipContentModel` [boolean] [default: false]
 
@@ -424,6 +424,8 @@ The ExO entities exported here are designed to be fed directly into [`contentful
 Releases export is on by default (`skipReleases: false`) — for the CLI and the module API alike. Pass `skipReleases: true` (`--skip-releases` on the CLI) to opt out.
 
 Only releases with `sys.schemaVersion: "Release.v2"` ("Releases") are fetched. `Release.v1` ("Launch") releases are excluded by the export query itself, since [`contentful-import`](https://github.com/contentful/contentful-import) only supports `Release.v2` on the import side.
+
+Only active Releases are exported. Archived Releases are omitted, regardless of `includeArchived`, because that option currently applies only to entries and assets.
 
 If the source space's organization lacks the Releases entitlement, or the fetch otherwise fails, a `Skipping Releases export` warning is logged and `releases` exports as an empty array — it does not fail the export.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -88,6 +88,7 @@ export default function runContentfulExport (params) {
             skipWebhooks: options.skipWebhooks,
             skipRoles: options.skipRoles,
             skipTags: options.skipTags,
+            skipReleases: options.skipReleases,
             stripTags: options.stripTags,
             includeExperienceOrchestration: options.includeExperienceOrchestration,
             listrOptions,

--- a/lib/parseOptions.js
+++ b/lib/parseOptions.js
@@ -19,6 +19,7 @@ export default function parseOptions (params) {
     skipAssets: false,
     skipWebhooks: false,
     skipTags: false,
+    skipReleases: false,
     stripTags: false,
     maxAllowedLimit: 1000,
     includeExperienceOrchestration: true,
@@ -92,6 +93,7 @@ export default function parseOptions (params) {
     options.skipRoles = true
     options.skipContentModel = true
     options.skipWebhooks = true
+    options.skipReleases = true
   }
 
   options.application = options.managementApplication || `contentful.export/${version}`

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -163,6 +163,31 @@ export default function getFullSourceSpace({
       skip: () => skipRoles || (environmentId !== 'master' && 'Roles can only be exported from master environment')
     },
     {
+      title: 'Fetching Experience Orchestration Releases',
+      task: wrapTask(async (ctx) => {
+        try {
+          const releases = await cursorPagedGet((query) => client.release.query({
+            environmentId,
+            spaceId,
+            query: {
+              "metadata.annotations.Contentful:Timeline.type[nin]": "Staging",
+              "sys.schemaVersion": "Release.v2",
+              "sys.status[in]": "active",
+              ...query
+            }
+          }))
+
+          console.log('JSON.stringify(releases) => ', JSON.stringify(releases, null, 4))
+
+          ctx.data.releases = releases
+
+        } catch (err) {
+          logEmitter.emit('warning', `Skipping Releases export: ${err.message}`)
+          ctx.data.releases = []
+        }
+      }),
+    },
+    {
       title: 'Fetching Design Tokens data',
       task: wrapTask(async (ctx) => {
         try {

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -22,6 +22,7 @@ export default function getFullSourceSpace({
   skipRoles,
   skipEditorInterfaces,
   skipTags,
+  skipReleases,
   stripTags,
   includeDrafts,
   includeArchived,
@@ -163,7 +164,7 @@ export default function getFullSourceSpace({
       skip: () => skipRoles || (environmentId !== 'master' && 'Roles can only be exported from master environment')
     },
     {
-      title: 'Fetching Experience Orchestration Releases',
+      title: 'Fetching Releases data',
       task: wrapTask(async (ctx) => {
         try {
           const releases = await cursorPagedGet((query) => client.release.query({
@@ -184,6 +185,7 @@ export default function getFullSourceSpace({
           ctx.data.releases = []
         }
       }),
+      skip: () => skipReleases
     },
     {
       title: 'Fetching Design Tokens data',

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -177,8 +177,6 @@ export default function getFullSourceSpace({
             }
           }))
 
-          console.log('JSON.stringify(releases) => ', JSON.stringify(releases, null, 4))
-
           ctx.data.releases = releases
 
         } catch (err) {

--- a/lib/tasks/get-space-data.js
+++ b/lib/tasks/get-space-data.js
@@ -167,19 +167,20 @@ export default function getFullSourceSpace({
       title: 'Fetching Releases data',
       task: wrapTask(async (ctx) => {
         try {
+          // Excludes releases created internally by other Contentful features (rather than by a
+          // user directly), so they don't leak into a customer's export as if they were
+          // user-authored Releases.
           const releases = await cursorPagedGet((query) => client.release.query({
             environmentId,
             spaceId,
             query: {
-              "metadata.annotations.Contentful:Timeline.type[nin]": "Staging",
-              "sys.schemaVersion": "Release.v2",
-              "sys.status[in]": "active",
+              'metadata.annotations.Contentful:Timeline.type[nin]': 'Staging,Hidden',
+              'sys.schemaVersion': 'Release.v2',
+              'sys.status[in]': 'active',
               ...query
             }
           }))
-
           ctx.data.releases = releases
-
         } catch (err) {
           logEmitter.emit('warning', `Skipping Releases export: ${err.message}`)
           ctx.data.releases = []

--- a/lib/usageParams.js
+++ b/lib/usageParams.js
@@ -67,6 +67,11 @@ export default yargs
     type: 'boolean',
     default: false
   })
+  .option('skip-releases', {
+    describe: 'Skip exporting Releases',
+    type: 'boolean',
+    default: false
+  })
   .options('strip-tags', {
     describe: 'Untag assets and entries',
     type: 'boolean',

--- a/test/integration/export-releases.test.js
+++ b/test/integration/export-releases.test.js
@@ -1,0 +1,104 @@
+import { join } from 'path'
+
+import mkdirp from 'mkdirp'
+import rimraf from 'rimraf'
+import { createClient } from 'contentful-management'
+
+import runContentfulExport from '../../dist/index'
+
+jest.setTimeout(180000)
+
+const tmpFolder = join(__dirname, 'tmp-releases')
+const managementToken = process.env.MANAGEMENT_TOKEN
+const organizationId = process.env.EXPORT_ORGANIZATION_ID
+
+const ENVIRONMENT_ID = 'master'
+const CONTENT_TYPE_ID = 'testPage'
+
+const rootClient = createClient({ accessToken: managementToken })
+
+let spaceId
+let client
+let entryId
+let releaseId
+
+beforeAll(async () => {
+  mkdirp.sync(tmpFolder)
+
+  const space = await rootClient.space.create({ organizationId }, { name: 'contentful-export-releases-test' })
+  spaceId = space.sys.id
+  client = createClient({ accessToken: managementToken }, { defaults: { spaceId, environmentId: ENVIRONMENT_ID } })
+
+  const contentType = await client.contentType.createWithId(
+    { contentTypeId: CONTENT_TYPE_ID },
+    {
+      name: 'Test Page',
+      displayField: 'title',
+      fields: [
+        { id: 'title', name: 'Title', type: 'Symbol', required: false, localized: false }
+      ]
+    }
+  )
+  const publishedContentType = await client.contentType.publish({ contentTypeId: contentType.sys.id }, contentType)
+
+  const entry = await client.entry.create(
+    { contentTypeId: publishedContentType.sys.id },
+    { fields: { title: { 'en-US': 'Test Page' } } }
+  )
+  const publishedEntry = await client.entry.publish({ entryId: entry.sys.id }, entry)
+  entryId = publishedEntry.sys.id
+
+  const release = await client.release.create(
+    {},
+    {
+      sys: { type: 'Release', schemaVersion: 'Release.v2' },
+      title: 'Test Release for export',
+      entities: {
+        sys: { type: 'Array' },
+        items: [
+          { entity: { sys: { type: 'Link', linkType: 'Entry', id: entryId } }, action: 'publish' }
+        ]
+      }
+    }
+  )
+  releaseId = release.sys.id
+})
+
+afterAll(async () => {
+  await client.release.delete({ releaseId })
+  await rootClient.space.delete({ spaceId })
+  rimraf.sync(tmpFolder)
+})
+
+describe('Releases', () => {
+  it('does not export releases when skipReleases is set', () => {
+    return runContentfulExport({
+      spaceId,
+      managementToken,
+      saveFile: false,
+      exportDir: tmpFolder,
+      skipReleases: true
+    }).then((content) => {
+      expect(content.releases).toBeUndefined()
+    })
+  })
+
+  it('exports the release with its title, schemaVersion, and entities collection', () => {
+    return runContentfulExport({
+      spaceId,
+      managementToken,
+      saveFile: false,
+      exportDir: tmpFolder
+    }).then((content) => {
+      expect(Array.isArray(content.releases)).toBe(true)
+      const exported = content.releases.find((r) => r.sys.id === releaseId)
+      expect(exported).toBeDefined()
+      expect(exported.title).toBe('Test Release for export')
+      expect(exported.sys.schemaVersion).toBe('Release.v2')
+      expect(exported.entities.items).toHaveLength(1)
+      expect(exported.entities.items[0].entity.sys.id).toBe(entryId)
+      expect(exported.entities.items[0].entity.sys.linkType).toBe('Entry')
+      expect(exported.entities.items[0].action).toBe('publish')
+    })
+  })
+})

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -1177,7 +1177,7 @@ function setupReleaseMock() {
   }
 }
 
-test('Fetches Releases data by default', () => {
+test('Fetches only active Releases by default', () => {
   setupReleaseMock()
   return getSpaceData({
     client: mockClient,

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -945,3 +945,113 @@ test('Degrades gracefully to an empty array when an ExO endpoint fails', () => {
       expect(response.data.designTokens).toHaveLength(1)
     })
 })
+
+// --- Releases (Timeline) ---
+//
+// Releases is a separate, GA Contentful feature, not part of Experience
+// Orchestration — it is fetched unconditionally (unlike the ExO entities
+// above, which are gated behind `includeExperienceOrchestration`) unless
+// `skipReleases` opts out. It uses the same cursor-based pagination helper
+// as the ExO entities, driven by `client.release.query`.
+
+function setupReleaseMock() {
+  mockClient.release = {
+    query: jest.fn(() => Promise.resolve(cursorPage([{ sys: { id: 'release1' } }])))
+  }
+}
+
+test('Fetches Releases data by default', () => {
+  setupReleaseMock()
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    skipContent: true,
+    skipWebhooks: true,
+    skipRoles: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      expect(mockClient.release.query.mock.calls).toHaveLength(1)
+      expect(mockClient.release.query.mock.calls[0][0]).toEqual({
+        spaceId: 'spaceid',
+        environmentId: 'master',
+        query: {
+          'metadata.annotations.Contentful:Timeline.type[nin]': 'Staging',
+          'sys.schemaVersion': 'Release.v2',
+          'sys.status[in]': 'active',
+          limit: maxAllowedLimit
+        }
+      })
+      expect(response.data.releases).toHaveLength(1)
+      expect(response.data.releases[0].sys.id).toBe('release1')
+    })
+})
+
+test('Skips Releases when skipReleases is set', () => {
+  setupReleaseMock()
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    skipContent: true,
+    skipWebhooks: true,
+    skipRoles: true,
+    skipReleases: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      expect(mockClient.release.query.mock.calls).toHaveLength(0)
+      expect(response.data.releases).toBeUndefined()
+    })
+})
+
+test('Follows cursor pagination across pages for Releases', () => {
+  setupReleaseMock()
+  mockClient.release.query = jest.fn()
+    .mockResolvedValueOnce(cursorPage([{ sys: { id: 'r1' } }, { sys: { id: 'r2' } }], 'RELEASE_PAGE_2'))
+    .mockResolvedValueOnce(cursorPage([{ sys: { id: 'r3' } }]))
+
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    skipContent: true,
+    skipWebhooks: true,
+    skipRoles: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      expect(mockClient.release.query.mock.calls).toHaveLength(2)
+      expect(mockClient.release.query.mock.calls[0][0].query).not.toHaveProperty('pageNext')
+      expect(mockClient.release.query.mock.calls[1][0].query.pageNext).toBe('RELEASE_PAGE_2')
+      expect(response.data.releases).toHaveLength(3)
+      expect(response.data.releases.map((item) => item.sys.id)).toEqual(['r1', 'r2', 'r3'])
+    })
+})
+
+test('Degrades gracefully to an empty array when the Releases endpoint fails', () => {
+  setupReleaseMock()
+  mockClient.release.query = jest.fn(() => Promise.reject(new Error('Timeline is not enabled for this organization')))
+
+  return getSpaceData({
+    client: mockClient,
+    spaceId: 'spaceid',
+    maxAllowedLimit,
+    skipContent: true,
+    skipWebhooks: true,
+    skipRoles: true
+  })
+    .run({
+      data: {}
+    })
+    .then((response) => {
+      expect(response.data.releases).toEqual([])
+    })
+})

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -946,7 +946,7 @@ test('Degrades gracefully to an empty array when an ExO endpoint fails', () => {
     })
 })
 
-// --- Releases (Timeline) ---
+// --- Timeline (Releases) ---
 //
 // Releases is a separate, GA Contentful feature, not part of Experience
 // Orchestration — it is fetched unconditionally (unlike the ExO entities

--- a/test/unit/tasks/get-space-data.test.js
+++ b/test/unit/tasks/get-space-data.test.js
@@ -979,7 +979,7 @@ test('Fetches Releases data by default', () => {
         spaceId: 'spaceid',
         environmentId: 'master',
         query: {
-          'metadata.annotations.Contentful:Timeline.type[nin]': 'Staging',
+          'metadata.annotations.Contentful:Timeline.type[nin]': 'Staging,Hidden',
           'sys.schemaVersion': 'Release.v2',
           'sys.status[in]': 'active',
           limit: maxAllowedLimit


### PR DESCRIPTION
[AIS-140](https://contentful.atlassian.net/browse/AIS-140)

## Summary
- Adds Releases (Timeline) export, on by default — pass `skipReleases: true` (`--skip-releases` on the CLI) to opt out. Releases is a separate, GA Contentful feature, not part of Experience Orchestration, and gated by its own organization entitlement.
- Only `Release.v2` ("Releases") is fetched — `Release.v1` ("Launch") is excluded by the query itself, since [`contentful-import`](https://github.com/contentful/contentful-import) only supports `Release.v2` on the import side. Releases created internally by other Contentful features (Experience Orchestration's publishing pipeline, Bulk AI Actions) are also excluded so they don't show up in a customer's export as if they were user-authored.
- If the source space's organization lacks the Releases entitlement, or the fetch otherwise fails, a warning is logged and `releases` exports as an empty array — it does not fail the export.
- Round-trips into the corresponding [`contentful-import`](https://github.com/contentful/contentful-import) branch, which imports each exported release. Worth knowing: Releases have no ID-preserving create on the API side, so re-importing the same export creates additional releases rather than updating existing ones — documented in both repos' READMEs.

## Test plan
- [x] Unit suite passes (65/65), including new coverage for the Releases fetch (default behavior, `skipReleases`, cursor pagination, graceful degradation on entitlement/fetch failure)
- [x] Lint and build clean
- [x] New integration test run live against a real sandbox space — seeds a real `Release.v2`, confirms it exports with title/schemaVersion/entities intact, and confirms `skipReleases` correctly omits the field
- [x] Manually verified a full export → import round trip against a real sandbox space, paired with the corresponding `contentful-import` branch

Generated with [Claude Code](https://claude.com/claude-code)

[AIS-140]: https://contentful.atlassian.net/browse/AIS-140?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ